### PR TITLE
[FIX] fixed sequence_info confusion

### DIFF
--- a/core/include/seqan/bam_io/bam_header_record.h
+++ b/core/include/seqan/bam_io/bam_header_record.h
@@ -292,14 +292,7 @@ swap(BamHeaderRecord &a, BamHeaderRecord &b)
 ..type:nolink:$String<BamHeaderRecord>$
 */
 
-class BamHeader
-{
-public:
-    typedef Pair<CharString, __int32> TSequenceInfo;
-
-    String<Pair<CharString, __int32> > sequenceInfos;
-    String<BamHeaderRecord> records;
-};
+typedef String<BamHeaderRecord> BamHeader;
 
 // ============================================================================
 // Metafunctions
@@ -522,11 +515,9 @@ searchRecord(unsigned & recordIdx,
              BamHeaderRecordType recordType,
              unsigned startIdx)
 {
-    for (recordIdx = startIdx; recordIdx < length(header.records); ++recordIdx)
-    {
-        if (header.records[recordIdx].type == recordType)
+    for (recordIdx = startIdx; recordIdx < length(header); ++recordIdx)
+        if (header[recordIdx].type == recordType)
             return true;
-    }
     return false;
 }
 
@@ -562,22 +553,20 @@ removeDuplicates(BamHeader & header)
     BamHeaderRecordTypeLess less;
     BamHeaderRecordEqual pred;
 
-    std::stable_sort(begin(header.records, Standard()), end(header.records, Standard()), less);
+    std::stable_sort(begin(header, Standard()), end(header, Standard()), less);
 
-    for (size_t uniqueBegin = 0, uniqueEnd = 1; uniqueEnd < length(header.records);)
+    for (size_t uniqueBegin = 0, uniqueEnd = 1; uniqueEnd < length(header);)
     {
-        if (less(header.records[uniqueBegin], header.records[uniqueEnd]))
+        if (less(header[uniqueBegin], header[uniqueEnd]))
             uniqueBegin = uniqueEnd;
 
         size_t j;
         for (j = uniqueBegin; j < uniqueEnd; ++j)
-        {
-            if (pred(header.records[j], header.records[uniqueEnd]))
+            if (pred(header[j], header[uniqueEnd]))
             {
-                erase(header.records, uniqueEnd);
+                erase(header, uniqueEnd);
                 break;
             }
-        }
 
         if (j == uniqueEnd)
             ++uniqueEnd;
@@ -590,7 +579,7 @@ getSortOrder(BamHeader const & header)
     CharString soString;
     for (unsigned recIdx = 0; searchRecord(recIdx, header, BAM_HEADER_FIRST, recIdx); ++recIdx)
     {
-        if (getTagValue(soString, "SO", header.records[recIdx]))
+        if (getTagValue(soString, "SO", header[recIdx]))
         {
             if (soString == "unsorted")
                 return BAM_SORT_UNSORTED;
@@ -611,7 +600,7 @@ setSortOrder(BamHeader & header, BamSortOrder sortOrder)
     for (unsigned recIdx = 0; searchRecord(recIdx, header, BAM_HEADER_FIRST, recIdx); ++recIdx)
     {
         unsigned idx = 0;
-        if (findTagKey(idx, "SO", header.records[recIdx]))
+        if (findTagKey(idx, "SO", header[recIdx]))
         {
             CharString soString;
             switch (sortOrder)
@@ -631,24 +620,10 @@ setSortOrder(BamHeader & header, BamSortOrder sortOrder)
                 default:
                     soString = "unknown";
             }
-            setTagValue(idx, soString, header.records[recIdx]);
+            setTagValue(idx, soString, header[recIdx]);
         }
     }
 }
-
-// ----------------------------------------------------------------------------
-// Function clear()
-// ----------------------------------------------------------------------------
-
-///.Function.clear.param.object.type:Class.BamHeader
-
-inline void
-clear(BamHeader & header)
-{
-    clear(header.sequenceInfos);
-    clear(header.records);
-}
-
 
 }  // namespace seqan
 

--- a/core/include/seqan/bam_io/write_bam.h
+++ b/core/include/seqan/bam_io/write_bam.h
@@ -88,8 +88,8 @@ void write(TTarget & target,
     clear(context.buffer);
 
     // Create text of header.
-    for (unsigned i = 0; i < length(header.records); ++i)
-        write(context.buffer, header.records[i], context, Sam());
+    for (unsigned i = 0; i < length(header); ++i)
+        write(context.buffer, header[i], context, Sam());
     
     // Note that we do not write out a null-character to terminate the header.  This would be valid by the SAM standard
     // but the samtools do not expect this and write out the '\0' when converting from BAM to SAM.
@@ -100,15 +100,25 @@ void write(TTarget & target,
     write(target, context.buffer);
 
     // Write references.
-    appendRawPod(target, (__int32)_max(length(header.sequenceInfos), length(nameStore(context))));
+    __int32 nRef = std::max(length(nameStore(context)), length(sequenceLengths(context)));
+    appendRawPod(target, nRef);
 
-    for (unsigned i = 0; i < length(header.sequenceInfos); ++i)
+    for (__int32 i = 0; i < nRef; ++i)
     {
-//        getIdByName(nameStoreCache(context), header.sequenceInfos[i].i1);
-        appendRawPod(target, (__int32)(length(header.sequenceInfos[i].i1) + 1));
-        write(target, header.sequenceInfos[i].i1);
+        if (i < (__int32)length(nameStore(context)))
+        {
+            appendRawPod(target, (__int32)(length(nameStore(context)[i]) + 1));
+            write(target, nameStore(context)[i]);
+        }
+        else
+        {
+            appendRawPod(target, (__int32)1);
+        }
         writeValue(target, '\0');
-        appendRawPod(target, (__int32)header.sequenceInfos[i].i2);
+        __int32 lRef = 0;
+        if (i < (__int32)length(sequenceLengths(context)))
+            lRef = sequenceLengths(context)[i];
+        appendRawPod(target, lRef);
     }
 }
 

--- a/core/include/seqan/basic/basic_stream.h
+++ b/core/include/seqan/basic/basic_stream.h
@@ -150,6 +150,44 @@ SEQAN_CONCEPT_REFINE(BidirectionalStreamConcept, (TStream), (InputStreamConcept)
 {};
 
 // ============================================================================
+// Exceptions
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Exception ParseError
+// ----------------------------------------------------------------------------
+
+struct ParseError : RuntimeError
+{
+    template <typename TString>
+    ParseError(TString const &message):
+        RuntimeError(message)
+    {}
+};
+
+// ----------------------------------------------------------------------------
+// Exception UnexpectedEnd
+// ----------------------------------------------------------------------------
+
+struct UnexpectedEnd : ParseError
+{
+    UnexpectedEnd():
+        ParseError("Unexpected end of input.")
+    {}
+};
+
+// ----------------------------------------------------------------------------
+// Exception EmptyFieldError
+// ----------------------------------------------------------------------------
+
+struct EmptyFieldError : ParseError
+{
+    EmptyFieldError(std::string fieldName):
+        ParseError(fieldName + " field was empty.")
+    {}
+};
+
+// ============================================================================
 // Metafunctions
 // ============================================================================
 
@@ -455,7 +493,7 @@ inline void _write(TTarget &target, TFwdIterator &iter, TSize n, Range<TIValue*>
     }
 }
 
-// chunked, target is pointer (e.g. readRawByte)
+// chunked, target is pointer (e.g. readRawPod)
 template <typename TOValue, typename TFwdIterator, typename TSize>
 inline SEQAN_FUNC_DISABLE_IF(IsSameType<typename Chunk<TFwdIterator>::Type, Nothing>, void)
 write(TOValue *ptr, TFwdIterator &iter, TSize n)
@@ -494,7 +532,7 @@ write(TOValue *ptr, TFwdIterator &iter, TSize n)
     }
 }
 
-// chunked, source is pointer (e.g. readRawByte)
+// chunked, source is pointer (e.g. readRawPod)
 template <typename TTarget, typename TIValue, typename TSize>
 inline SEQAN_FUNC_DISABLE_IF(IsSameType<typename Chunk<TTarget>::Type, Nothing>, void)
 write(TTarget &target, TIValue *ptr, TSize n)

--- a/core/include/seqan/sequence/string_base.h
+++ b/core/include/seqan/sequence/string_base.h
@@ -2186,6 +2186,21 @@ operator>>(TStream & source,
     return source;
 }
 
+// ----------------------------------------------------------------------------
+// Function assignValueById
+// ----------------------------------------------------------------------------
+
+template<typename TValue, typename TSpec, typename TId>
+inline SEQAN_FUNC_ENABLE_IF(Is<IntegerConcept<TId> >, void)
+assignValueById(String<TValue, TSpec> & me,
+                TId id,
+                TValue const & obj)
+{
+    if (length(me) <= id)
+        resize(me, id + 1, TValue());
+    assignValue(me, id, obj);
+}
+
 }  // namespace seqan
 
 #endif  // #ifndef SEQAN_SEQUENCE_STRING_ARRAY_BASE_H_

--- a/core/include/seqan/stream/tokenization.h
+++ b/core/include/seqan/stream/tokenization.h
@@ -40,44 +40,6 @@
 namespace seqan {
 
 // ============================================================================
-// Exceptions
-// ============================================================================
-
-// ----------------------------------------------------------------------------
-// Exception ParseError
-// ----------------------------------------------------------------------------
-
-struct ParseError : RuntimeError
-{
-    template <typename TString>
-    ParseError(TString const &message):
-        RuntimeError(message)
-    {}
-};
-
-// ----------------------------------------------------------------------------
-// Exception UnexpectedEnd
-// ----------------------------------------------------------------------------
-
-struct UnexpectedEnd : ParseError
-{
-    UnexpectedEnd():
-        ParseError("Unexpected end of input.")
-    {}
-};
-
-// ----------------------------------------------------------------------------
-// Exception EmptyFieldError
-// ----------------------------------------------------------------------------
-
-struct EmptyFieldError : ParseError
-{
-    EmptyFieldError(std::string fieldName):
-        ParseError(fieldName + " field was empty.")
-    {}
-};
-
-// ============================================================================
 // Functors
 // ============================================================================
 
@@ -434,23 +396,8 @@ inline void readOne(TTarget & target, TFwdIterator &iter)
 // ----------------------------------------------------------------------------
 
 //TODO(singer) to be revised
-/*
-template <typename TTarget, typename TFwdIterator, typename TNumber>
-inline void readRawByte(TTarget & target, TFwdIterator &iter, TNumber numberOfBytes)
-{
-    char * buffer = reinterpret_cast<char *>(&target);
-    for (; !numberOfBytes(*iter); ++buffer, ++iter)
-        *buffer = *iter;
-
-    if (numberOfBytes(*iter))
-        throw UnexpectedEnd();
-
-}
-*/
-
-//TODO(singer) to be revised
 template <typename TValue, typename TFwdIterator>
-inline void readRawByte(TValue & value, TFwdIterator &srcIter)
+inline void readRawPod(TValue & value, TFwdIterator &srcIter)
 {
     write((char*)&value, srcIter, sizeof(TValue));
 }

--- a/core/tests/bam_io/test_bam_file.h
+++ b/core/tests/bam_io/test_bam_file.h
@@ -56,20 +56,19 @@ void testBamIOBamFileReadHeader(char const * pathFragment)
 
     readRecord(header, bamIO);
 
-    SEQAN_ASSERT_EQ(length(header.records), 2u);
-    SEQAN_ASSERT_EQ(header.records[0].type, seqan::BAM_HEADER_FIRST);
-    SEQAN_ASSERT_EQ(header.records[0].tags[0].i1, "VN");
-    SEQAN_ASSERT_EQ(header.records[0].tags[0].i2, "1.3");
-    SEQAN_ASSERT_EQ(header.records[0].tags[1].i1, "SO");
-    SEQAN_ASSERT_EQ(header.records[0].tags[1].i2, "coordinate");
-    SEQAN_ASSERT_EQ(header.records[1].type, seqan::BAM_HEADER_REFERENCE);
-    SEQAN_ASSERT_EQ(header.records[1].tags[0].i1, "SN");
-    SEQAN_ASSERT_EQ(header.records[1].tags[0].i2, "REFERENCE");
-    SEQAN_ASSERT_EQ(header.records[1].tags[1].i1, "LN");
-    SEQAN_ASSERT_EQ(header.records[1].tags[1].i2, "10000");
-    SEQAN_ASSERT_EQ(length(header.sequenceInfos), 1u);
-    SEQAN_ASSERT_EQ(header.sequenceInfos[0].i1, "REFERENCE");
-    SEQAN_ASSERT_EQ(header.sequenceInfos[0].i2, 10000);
+    SEQAN_ASSERT_EQ(length(header), 2u);
+    SEQAN_ASSERT_EQ(header[0].type, seqan::BAM_HEADER_FIRST);
+    SEQAN_ASSERT_EQ(header[0].tags[0].i1, "VN");
+    SEQAN_ASSERT_EQ(header[0].tags[0].i2, "1.3");
+    SEQAN_ASSERT_EQ(header[0].tags[1].i1, "SO");
+    SEQAN_ASSERT_EQ(header[0].tags[1].i2, "coordinate");
+    SEQAN_ASSERT_EQ(header[1].type, seqan::BAM_HEADER_REFERENCE);
+    SEQAN_ASSERT_EQ(header[1].tags[0].i1, "SN");
+    SEQAN_ASSERT_EQ(header[1].tags[0].i2, "REFERENCE");
+    SEQAN_ASSERT_EQ(header[1].tags[1].i1, "LN");
+    SEQAN_ASSERT_EQ(header[1].tags[1].i2, "10000");
+    SEQAN_ASSERT_EQ(length(sequenceLengths(context(bamIO))), 1u);
+    SEQAN_ASSERT_EQ(sequenceLengths(context(bamIO))[0], 10000);
 }
 
 SEQAN_DEFINE_TEST(test_bam_io_bam_file_sam_read_header)
@@ -224,22 +223,20 @@ void testBamIOBamFileWriteHeader(char const * pathFragmentExpected)
     seqan::BamFileOut bamIO(toCString(tmpPath));
 
     seqan::BamHeader header;
-    resize(header.sequenceInfos, 1);
-    header.sequenceInfos[0].i1 = "REFERENCE";
-    header.sequenceInfos[0].i2 = 10000;
-    resize(header.records, 2);
-    resize(header.records[0].tags, 2);
-    header.records[0].type = seqan::BAM_HEADER_FIRST;
-    header.records[0].tags[0].i1 = "VN";
-    header.records[0].tags[0].i2 = "1.3";
-    header.records[0].tags[1].i1 = "SO";
-    header.records[0].tags[1].i2 = "coordinate";
-    resize(header.records[1].tags, 2);
-    header.records[1].type = seqan::BAM_HEADER_REFERENCE;
-    header.records[1].tags[0].i1 = "SN";
-    header.records[1].tags[0].i2 = "REFERENCE";
-    header.records[1].tags[1].i1 = "LN";
-    header.records[1].tags[1].i2 = "10000";
+    assignValueById(sequenceLengths(context(bamIO)), nameToId(nameStoreCache(context(bamIO)), "REFERENCE"), 10000);
+    resize(header, 2);
+    resize(header[0].tags, 2);
+    header[0].type = seqan::BAM_HEADER_FIRST;
+    header[0].tags[0].i1 = "VN";
+    header[0].tags[0].i2 = "1.3";
+    header[0].tags[1].i1 = "SO";
+    header[0].tags[1].i2 = "coordinate";
+    resize(header[1].tags, 2);
+    header[1].type = seqan::BAM_HEADER_REFERENCE;
+    header[1].tags[0].i1 = "SN";
+    header[1].tags[0].i2 = "REFERENCE";
+    header[1].tags[1].i1 = "LN";
+    header[1].tags[1].i2 = "10000";
     writeRecord(bamIO, header);
 
     // Force writing of header on flush.
@@ -281,22 +278,20 @@ void testBamIOBamFileWriteRecords(char const * pathFragmentExpected)
     seqan::BamFileOut bamIO(toCString(tmpPath));
 
     seqan::BamHeader header;
-    resize(header.sequenceInfos, 1);
-    header.sequenceInfos[0].i1 = "REFERENCE";
-    header.sequenceInfos[0].i2 = 10000;
-    resize(header.records, 2);
-    resize(header.records[0].tags, 2);
-    header.records[0].type = seqan::BAM_HEADER_FIRST;
-    header.records[0].tags[0].i1 = "VN";
-    header.records[0].tags[0].i2 = "1.3";
-    header.records[0].tags[1].i1 = "SO";
-    header.records[0].tags[1].i2 = "coordinate";
-    resize(header.records[1].tags, 2);
-    header.records[1].type = seqan::BAM_HEADER_REFERENCE;
-    header.records[1].tags[0].i1 = "SN";
-    header.records[1].tags[0].i2 = "REFERENCE";
-    header.records[1].tags[1].i1 = "LN";
-    header.records[1].tags[1].i2 = "10000";
+    assignValueById(sequenceLengths(context(bamIO)), nameToId(nameStoreCache(context(bamIO)), "REFERENCE"), 10000);
+    resize(header, 2);
+    resize(header[0].tags, 2);
+    header[0].type = seqan::BAM_HEADER_FIRST;
+    header[0].tags[0].i1 = "VN";
+    header[0].tags[0].i2 = "1.3";
+    header[0].tags[1].i1 = "SO";
+    header[0].tags[1].i2 = "coordinate";
+    resize(header[1].tags, 2);
+    header[1].type = seqan::BAM_HEADER_REFERENCE;
+    header[1].tags[0].i1 = "SN";
+    header[1].tags[0].i2 = "REFERENCE";
+    header[1].tags[1].i1 = "LN";
+    header[1].tags[1].i2 = "10000";
     writeRecord(bamIO, header);
 
     // Construct first records.

--- a/core/tests/bam_io/test_bam_header_record.h
+++ b/core/tests/bam_io/test_bam_header_record.h
@@ -55,7 +55,7 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_header_typedefs)
 {
     using namespace seqan;
 
-    typedef BamHeader::TSequenceInfo TSequenceInfo SEQAN_UNUSED_TYPEDEF;
+    typedef BamIOContext<>::TSequenceLengths TSequenceLengths SEQAN_UNUSED_TYPEDEF;
 }
 
 SEQAN_DEFINE_TEST(test_bam_io_bam_header_record_class)

--- a/core/tests/bam_io/test_read_bam.h
+++ b/core/tests/bam_io/test_read_bam.h
@@ -73,28 +73,27 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_read_header)
     // Check Results.
     // -----------------------------------------------------------------------
 
-    SEQAN_ASSERT_EQ(length(header.sequenceInfos), 1u);
-    SEQAN_ASSERT_EQ(header.sequenceInfos[0].i1, "REFERENCE");
-    SEQAN_ASSERT_EQ(header.sequenceInfos[0].i2, 10000);
+    SEQAN_ASSERT_EQ(length(sequenceLengths(bamIOContext)), 1u);
+    SEQAN_ASSERT_EQ(sequenceLengths(bamIOContext)[0], 10000);
 
     SEQAN_ASSERT_EQ(length(referenceNameStore), 1u);
     SEQAN_ASSERT_EQ(referenceNameStore[0], "REFERENCE");
 
-    SEQAN_ASSERT_EQ(length(header.records), 2u);
+    SEQAN_ASSERT_EQ(length(header), 2u);
 
-    SEQAN_ASSERT_EQ(header.records[0].type, BAM_HEADER_FIRST);
-    SEQAN_ASSERT_EQ(length(header.records[0].tags), 2u);
-    SEQAN_ASSERT_EQ(header.records[0].tags[0].i1, "VN");
-    SEQAN_ASSERT_EQ(header.records[0].tags[0].i2, "1.3");
-    SEQAN_ASSERT_EQ(header.records[0].tags[1].i1, "SO");
-    SEQAN_ASSERT_EQ(header.records[0].tags[1].i2, "coordinate");
+    SEQAN_ASSERT_EQ(header[0].type, BAM_HEADER_FIRST);
+    SEQAN_ASSERT_EQ(length(header[0].tags), 2u);
+    SEQAN_ASSERT_EQ(header[0].tags[0].i1, "VN");
+    SEQAN_ASSERT_EQ(header[0].tags[0].i2, "1.3");
+    SEQAN_ASSERT_EQ(header[0].tags[1].i1, "SO");
+    SEQAN_ASSERT_EQ(header[0].tags[1].i2, "coordinate");
 
-    SEQAN_ASSERT_EQ(header.records[1].type, BAM_HEADER_REFERENCE);
-    SEQAN_ASSERT_EQ(length(header.records[1].tags), 2u);
-    SEQAN_ASSERT_EQ(header.records[1].tags[0].i1, "SN");
-    SEQAN_ASSERT_EQ(header.records[1].tags[0].i2, "REFERENCE");
-    SEQAN_ASSERT_EQ(header.records[1].tags[1].i1, "LN");
-    SEQAN_ASSERT_EQ(header.records[1].tags[1].i2, "10000");
+    SEQAN_ASSERT_EQ(header[1].type, BAM_HEADER_REFERENCE);
+    SEQAN_ASSERT_EQ(length(header[1].tags), 2u);
+    SEQAN_ASSERT_EQ(header[1].tags[0].i1, "SN");
+    SEQAN_ASSERT_EQ(header[1].tags[0].i2, "REFERENCE");
+    SEQAN_ASSERT_EQ(header[1].tags[1].i1, "LN");
+    SEQAN_ASSERT_EQ(header[1].tags[1].i2, "10000");
 }
 
 SEQAN_DEFINE_TEST(test_bam_io_bam_read_alignment)

--- a/core/tests/bam_io/test_read_sam.h
+++ b/core/tests/bam_io/test_read_sam.h
@@ -73,28 +73,27 @@ SEQAN_DEFINE_TEST(test_bam_io_sam_read_header)
     // Check Results.
     // -----------------------------------------------------------------------
 
-    SEQAN_ASSERT_EQ(length(header.sequenceInfos), 1u);
-    SEQAN_ASSERT_EQ(header.sequenceInfos[0].i1, "REFERENCE");
-    SEQAN_ASSERT_EQ(header.sequenceInfos[0].i2, 10000);
+    SEQAN_ASSERT_EQ(length(sequenceLengths(bamIOContext)), 1u);
+    SEQAN_ASSERT_EQ(sequenceLengths(bamIOContext)[0], 10000);
 
     SEQAN_ASSERT_EQ(length(referenceNameStore), 1u);
     SEQAN_ASSERT_EQ(referenceNameStore[0], "REFERENCE");
 
-    SEQAN_ASSERT_EQ(length(header.records), 2u);
+    SEQAN_ASSERT_EQ(length(header), 2u);
 
-    SEQAN_ASSERT_EQ(header.records[0].type, BAM_HEADER_FIRST);
-    SEQAN_ASSERT_EQ(length(header.records[0].tags), 2u);
-    SEQAN_ASSERT_EQ(header.records[0].tags[0].i1, "VN");
-    SEQAN_ASSERT_EQ(header.records[0].tags[0].i2, "1.3");
-    SEQAN_ASSERT_EQ(header.records[0].tags[1].i1, "SO");
-    SEQAN_ASSERT_EQ(header.records[0].tags[1].i2, "coordinate");
+    SEQAN_ASSERT_EQ(header[0].type, BAM_HEADER_FIRST);
+    SEQAN_ASSERT_EQ(length(header[0].tags), 2u);
+    SEQAN_ASSERT_EQ(header[0].tags[0].i1, "VN");
+    SEQAN_ASSERT_EQ(header[0].tags[0].i2, "1.3");
+    SEQAN_ASSERT_EQ(header[0].tags[1].i1, "SO");
+    SEQAN_ASSERT_EQ(header[0].tags[1].i2, "coordinate");
 
-    SEQAN_ASSERT_EQ(header.records[1].type, BAM_HEADER_REFERENCE);
-    SEQAN_ASSERT_EQ(length(header.records[1].tags), 2u);
-    SEQAN_ASSERT_EQ(header.records[1].tags[0].i1, "SN");
-    SEQAN_ASSERT_EQ(header.records[1].tags[0].i2, "REFERENCE");
-    SEQAN_ASSERT_EQ(header.records[1].tags[1].i1, "LN");
-    SEQAN_ASSERT_EQ(header.records[1].tags[1].i2, "10000");
+    SEQAN_ASSERT_EQ(header[1].type, BAM_HEADER_REFERENCE);
+    SEQAN_ASSERT_EQ(length(header[1].tags), 2u);
+    SEQAN_ASSERT_EQ(header[1].tags[0].i1, "SN");
+    SEQAN_ASSERT_EQ(header[1].tags[0].i2, "REFERENCE");
+    SEQAN_ASSERT_EQ(header[1].tags[1].i1, "LN");
+    SEQAN_ASSERT_EQ(header[1].tags[1].i2, "10000");
 }
 
 SEQAN_DEFINE_TEST(test_bam_io_sam_read_alignment)

--- a/core/tests/bam_io/test_write_bam.h
+++ b/core/tests/bam_io/test_write_bam.h
@@ -46,7 +46,6 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_write_header)
 {
     using namespace seqan;
 
-    typedef typename BamHeader::TSequenceInfo TSequenceInfo;
     typedef typename BamHeaderRecord::TTag    TTag;
 
     // Prepare input.
@@ -57,18 +56,18 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_write_header)
     BamIOContext<StringSet<CharString> > bamIOContext(contigNameStore, contigNameStoreCache);
 
     BamHeader header;
-    appendValue(header.sequenceInfos, TSequenceInfo("REFERENCE", 10000));
+    appendValue(sequenceLengths(bamIOContext), 10000);
 
     BamHeaderRecord firstRecord;
     firstRecord.type = BAM_HEADER_FIRST;
     appendValue(firstRecord.tags, TTag("VN", "1.0"));
-    appendValue(header.records, firstRecord);
+    appendValue(header, firstRecord);
 
     BamHeaderRecord seqRecord;
     seqRecord.type = BAM_HEADER_REFERENCE;
     appendValue(seqRecord.tags, TTag("SN", "REFERENCE"));
     appendValue(seqRecord.tags, TTag("LN", "10000"));
-    appendValue(header.records, seqRecord);
+    appendValue(header, seqRecord);
 
     // Call code under test.
     String<char> text;
@@ -93,7 +92,6 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_write_alignment)
 {
     using namespace seqan;
 
-    typedef typename BamHeader::TSequenceInfo TSequenceInfo;
     typedef typename BamHeaderRecord::TTag    TTag;
 
     // Create input.
@@ -104,18 +102,18 @@ SEQAN_DEFINE_TEST(test_bam_io_bam_write_alignment)
     BamIOContext<StringSet<CharString> > bamIOContext(contigNameStore, contigNameStoreCache);
 
     BamHeader header;
-    appendValue(header.sequenceInfos, TSequenceInfo("REFERENCE", 10000));
+    appendValue(sequenceLengths(bamIOContext), 10000);
 
     BamHeaderRecord firstRecord;
     firstRecord.type = BAM_HEADER_FIRST;
     appendValue(firstRecord.tags, TTag("VN", "1.0"));
-    appendValue(header.records, firstRecord);
+    appendValue(header, firstRecord);
 
     BamHeaderRecord seqRecord;
     seqRecord.type = BAM_HEADER_REFERENCE;
     appendValue(seqRecord.tags, TTag("SN", "REFERENCE"));
     appendValue(seqRecord.tags, TTag("LN", "10000"));
-    appendValue(header.records, seqRecord);
+    appendValue(header, seqRecord);
 
     // Call code under test.
     String<char> text;

--- a/core/tests/bam_io/test_write_sam.h
+++ b/core/tests/bam_io/test_write_sam.h
@@ -44,7 +44,6 @@ SEQAN_DEFINE_TEST(test_bam_io_sam_write_header)
 {
     using namespace seqan;
 
-    typedef typename BamHeader::TSequenceInfo TSequenceInfo;
     typedef typename BamHeaderRecord::TTag    TTag;
 
     // Prepare input.
@@ -55,18 +54,18 @@ SEQAN_DEFINE_TEST(test_bam_io_sam_write_header)
     BamIOContext<StringSet<CharString> > bamIOContext(contigNameStore, contigNameStoreCache);
     
     BamHeader header;
-    appendValue(header.sequenceInfos, TSequenceInfo("REF", 10000));
+    appendValue(sequenceLengths(bamIOContext), 10000);
 
     BamHeaderRecord firstRecord;
     firstRecord.type = BAM_HEADER_FIRST;
     appendValue(firstRecord.tags, TTag("VN", "1.0"));
-    appendValue(header.records, firstRecord);
+    appendValue(header, firstRecord);
 
     BamHeaderRecord seqRecord;
     seqRecord.type = BAM_HEADER_REFERENCE;
     appendValue(seqRecord.tags, TTag("SN", "REF"));
     appendValue(seqRecord.tags, TTag("LN", "10000"));
-    appendValue(header.records, seqRecord);
+    appendValue(header, seqRecord);
 
     // Call code under test.
     String<char> buffer;


### PR DESCRIPTION
The sequence infos used BAM local id. I replaced it to use globalID == ids which refer to the nameStore of the BamIOContext. Thus the infos now correspond 1-to-1 to the shared sequences
