### PR TITLE
[API] ArgParseArgument::{INPUT,OUTPUT}FILE => {INPUT,OUTPUT}_FILE

### DIFF
--- a/core/apps/dfi/dfi.cpp
+++ b/core/apps/dfi/dfi.cpp
@@ -680,7 +680,7 @@ void setUpArgumentParser(ArgumentParser & parser, DFIOptions const &)
     setDate(parser, SEQAN_DATE);
 #endif
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "DATABASE", true));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "DATABASE", true));
     setValidValues(parser, 0, SeqFileIn::getFileFormatExtensions());
     setHelpText(parser, 0, "Database files in Fasta/Fastq or text format (lines are strings).");
 

--- a/core/apps/fiona/compute_gain.cpp
+++ b/core/apps/fiona/compute_gain.cpp
@@ -794,21 +794,21 @@ parseCommandLine(Options & options, int argc, char const ** argv)
 
     addSection(parser, "Input / Output");
 
-    addOption(parser, seqan::ArgParseOption("g", "genome", "Genome file.", seqan::ArgParseOption::INPUTFILE,
+    addOption(parser, seqan::ArgParseOption("g", "genome", "Genome file.", seqan::ArgParseOption::INPUT_FILE,
                                             "GENOME.fa"));
     setRequired(parser, "genome");
     setValidValues(parser, "genome", "fa fasta");
 
-    addOption(parser, seqan::ArgParseOption("", "pre", "Pre-correction SAM file.", seqan::ArgParseOption::INPUTFILE,
+    addOption(parser, seqan::ArgParseOption("", "pre", "Pre-correction SAM file.", seqan::ArgParseOption::INPUT_FILE,
                                             "PRE.{sam,bam}"));
     setRequired(parser, "pre");
     setValidValues(parser, "pre", "sam bam");
 
-    addOption(parser, seqan::ArgParseOption("", "post-sam", "Post-correction SAM file.", seqan::ArgParseOption::INPUTFILE,
+    addOption(parser, seqan::ArgParseOption("", "post-sam", "Post-correction SAM file.", seqan::ArgParseOption::INPUT_FILE,
                                             "POST.sam"));
     setValidValues(parser, "post-sam", "sam");
 
-    addOption(parser, seqan::ArgParseOption("", "post", "Post-correction FASTQ or FASTA file.", seqan::ArgParseOption::INPUTFILE,
+    addOption(parser, seqan::ArgParseOption("", "post", "Post-correction FASTQ or FASTA file.", seqan::ArgParseOption::INPUT_FILE,
                                             "POST.fq"));
     setValidValues(parser, "post", "fastq fq fastq.gz fq.gz fasta fa fasta.gz fa.gz");
 

--- a/core/apps/fiona/fiona.cpp
+++ b/core/apps/fiona/fiona.cpp
@@ -5100,7 +5100,7 @@ parseCommandLine(FionaOptions & options, int argc, char const ** argv)
                    "The reads are read from the file \\fIIN.{fq,fa}\\fP and are written to \\fIOUT.fa\\fP.");
 
     // Fiona gets two parameters:  The paths to the input and the output files.
-    addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUTFILE, "IN"));
+    addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUT_FILE, "IN"));
     setValidValues(parser, 0, "fa fasta fq fastq");
     setHelpText(parser, 0, "An input file with reads to be corrected.");
     addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::OUTPUTFILE, "OUT"));

--- a/core/apps/micro_razers/micro_razers.cpp
+++ b/core/apps/micro_razers/micro_razers.cpp
@@ -223,10 +223,10 @@ int main(int argc, const char *argv[])
     setVersion(parser, "1.0.1");
     setDate(parser, "Jul 2009" );
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     setValidValues(parser, 0, seqan::SeqFileIn::getFileFormatExtensions());
     setHelpText(parser, 0, "A reference genome file.");
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "READS", true));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "READS", true));
     setValidValues(parser, 1, seqan::SeqFileIn::getFileFormatExtensions());
     setHelpText(parser, 1, "Either one (single-end) or two (paired-end) read files.");
 

--- a/core/apps/pair_align/pair_align.cpp
+++ b/core/apps/pair_align/pair_align.cpp
@@ -346,7 +346,7 @@ parseCommandLine(Options & options, int argc, char const ** argv)
                    "tweaking various parameters.");
 
     addSection(parser, "Main Options");
-    addOption(parser, seqan::ArgParseOption("s", "seq", "FASTA file with two sequences.", seqan::ArgParseOption::INPUTFILE, "IN"));
+    addOption(parser, seqan::ArgParseOption("s", "seq", "FASTA file with two sequences.", seqan::ArgParseOption::INPUT_FILE, "IN"));
     setRequired(parser, "seq");
     setValidValues(parser, "seq", getFileFormatExtensions(Fasta()));
     addOption(parser, seqan::ArgParseOption("a", "alphabet", "Sequence alphabet.", seqan::ArgParseOption::STRING, "ALPHABET"));

--- a/core/apps/rabema/prepare_sam.cpp
+++ b/core/apps/rabema/prepare_sam.cpp
@@ -168,7 +168,7 @@ parseCommandLine(Options & options, int argc, char const ** argv)
     // Define Options.
     addOption(parser, seqan::ArgParseOption(
             "i", "in-file", "Path to the input file.",
-            seqan::ArgParseArgument::INPUTFILE, "IN.sam"));
+            seqan::ArgParseArgument::INPUT_FILE, "IN.sam"));
     setValidValues(parser, "in-file", "sam");
     setRequired(parser, "in-file");
 

--- a/core/apps/rabema/rabema_build_gold_standard.cpp
+++ b/core/apps/rabema/rabema_build_gold_standard.cpp
@@ -1000,11 +1000,11 @@ parseCommandLine(BuildGoldStandardOptions & options, int argc, char const ** arg
     setValidValues(parser, "out-gsi", "gsi gsi.gz");
     setRequired(parser, "out-gsi", true);
     addOption(parser, seqan::ArgParseOption("r", "reference", "Path to load reference FASTA from.",
-                                            seqan::ArgParseArgument::INPUTFILE, "FASTA"));
+                                            seqan::ArgParseArgument::INPUT_FILE, "FASTA"));
     setRequired(parser, "reference", true);
     setValidValues(parser, "reference", "fa fasta");
     addOption(parser, seqan::ArgParseOption("b", "in-bam", "Path to load the \"perfect\" SAM/BAM file from.",
-                                            seqan::ArgParseArgument::INPUTFILE, "BAM"));
+                                            seqan::ArgParseArgument::INPUT_FILE, "BAM"));
     setValidValues(parser, "in-bam", BamFileIn::getFileFormatExtensions());
 
     addSection(parser, "Gold Standard Parameters");

--- a/core/apps/rabema/rabema_evaluate.cpp
+++ b/core/apps/rabema/rabema_evaluate.cpp
@@ -1063,18 +1063,18 @@ parseCommandLine(RabemaEvaluationOptions & options, int argc, char const ** argv
     //                                         seqan::ArgParseArgument::STRING, false, "GSI"));
     // setRequired(parser, "out-gsi", true);
     addOption(parser, seqan::ArgParseOption("r", "reference", "Path to load reference FASTA from.",
-                                            seqan::ArgParseArgument::INPUTFILE, "FASTA"));
+                                            seqan::ArgParseArgument::INPUT_FILE, "FASTA"));
     setValidValues(parser, "reference", "fa fasta");
     setRequired(parser, "reference", true);
     addOption(parser, seqan::ArgParseOption("g", "in-gsi",
                                             "Path to load gold standard intervals from. If compressed using gzip, "
                                             "the file will be decompressed on the fly.",
-                                            seqan::ArgParseArgument::INPUTFILE, "GSI"));
+                                            seqan::ArgParseArgument::INPUT_FILE, "GSI"));
     setRequired(parser, "in-gsi", true);
     setValidValues(parser, "in-gsi", "gsi gsi.gz");  // GSI (Gold Standard Intervals) Format only.
 
     addOption(parser, seqan::ArgParseOption("b", "in-bam", "Path to load the read mapper SAM or BAM output from.",
-                                            seqan::ArgParseArgument::INPUTFILE, "BAM"));
+                                            seqan::ArgParseArgument::INPUT_FILE, "BAM"));
     setValidValues(parser, "in-bam", BamFileIn::getFileFormatExtensions());
     setRequired(parser, "in-bam");
     addOption(parser, seqan::ArgParseOption("", "out-tsv", "Path to write the statistics to as TSV.",

--- a/core/apps/razers/razers.cpp
+++ b/core/apps/razers/razers.cpp
@@ -248,10 +248,10 @@ void setUpArgumentParser(ArgumentParser & parser, RazerSOptions<> const & option
 	setDate(parser, SEQAN_DATE);
 #endif
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     setValidValues(parser, 0, seqan::SeqFileIn::getFileFormatExtensions());
     setHelpText(parser, 0, "A reference genome file.");
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "READS", true));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "READS", true));
     setValidValues(parser, 1, seqan::SeqFileIn::getFileFormatExtensions());
     setHelpText(parser, 1, "Either one (single-end) or two (paired-end) read files.");
 

--- a/core/apps/razers2/razers.cpp
+++ b/core/apps/razers2/razers.cpp
@@ -238,10 +238,10 @@ void setUpArgumentParser(ArgumentParser & parser, RazerSOptions<> const & option
     setDate(parser, SEQAN_DATE);
 #endif
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     setValidValues(parser, 0, seqan::SeqFileIn::getFileFormatExtensions());
     setHelpText(parser, 0, "A reference genome file.");
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "READS", true));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "READS", true));
     setValidValues(parser, 1, seqan::SeqFileIn::getFileFormatExtensions());
     setHelpText(parser, 1, "Either one (single-end) or two (paired-end) read files.");
 

--- a/core/apps/sak/sak.cpp
+++ b/core/apps/sak/sak.cpp
@@ -148,7 +148,7 @@ parseArgs(SakOptions & options,
     addDescription(parser, "Original SAK tool by David Weese. Rewrite by Manuel Holtgrewe.");
 
     // The only argument is the input file.
-    addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUTFILE, "IN"));
+    addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUT_FILE, "IN"));
 
     // Only FASTA and FASTQ files are allowed as input.
     setValidValues(parser, 0, seqan::SeqFileIn::getFileFormatExtensions());

--- a/core/apps/sam2matrix/sam2matrix.cpp
+++ b/core/apps/sam2matrix/sam2matrix.cpp
@@ -90,12 +90,12 @@ parseCommandLine(SamToGasicOptions& options, int argc, char const ** argv)
                            "provided sam files stating that it mapped. Afterwards a file is generated containing a row"
                            " for each read which contains the read ID and the index of the mapped references.");
 
-    addOption(parser, ArgParseOption("m", "mapping", "File containing the mappings.", ArgParseOption::INPUTFILE, 
+    addOption(parser, ArgParseOption("m", "mapping", "File containing the mappings.", ArgParseOption::INPUT_FILE, 
                                      "FILE", true));
     setValidValues(parser, "mapping", BamFileIn::getFileFormatExtensions());
     setRequired(parser, "mapping");
     addOption(parser, ArgParseOption("r", "reads", "File containing the reads contained in the mapping file(s).", 
-                                     ArgParseOption::INPUTFILE, "FILE"));
+                                     ArgParseOption::INPUT_FILE, "FILE"));
     setValidValues(parser, "reads", SeqFileIn::getFileFormatExtensions());
     setRequired(parser, "reads");
 

--- a/core/apps/samcat/bamsort.cpp
+++ b/core/apps/samcat/bamsort.cpp
@@ -436,7 +436,7 @@ parseCommandLine(AppOptions & options, int argc, char const ** argv)
     setValidValues(parser, "output", BamOnlyFileOut::getFileFormatExtensions());
 
     // We require one argument.
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "INFILE"));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "INFILE"));
     setValidValues(parser, 0, BamOnlyFileIn::getFileFormatExtensions());
     setHelpText(parser, 0, "Input BAM file (or - for stdin).");
 	addOption(parser, ArgParseOption("s", "sort-order", "Sort by either reference coordinate or query name.", ArgParseOption::STRING));

--- a/core/apps/samcat/samcat.cpp
+++ b/core/apps/samcat/samcat.cpp
@@ -181,7 +181,7 @@ parseCommandLine(AppOptions & options, int argc, char const ** argv)
     setValidValues(parser, "output", BamFileOut::getFileFormatExtensions());
 
     // We require one argument.
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "INFILE", true));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "INFILE", true));
     setValidValues(parser, 0, BamFileIn::getFileFormatExtensions());
 #if SEQAN_HAS_ZLIB
     setHelpText(parser, 0, "Input SAM or BAM file (or - for stdin).");

--- a/core/apps/seqan_tcoffee/seqan_tcoffee.cpp
+++ b/core/apps/seqan_tcoffee/seqan_tcoffee.cpp
@@ -330,7 +330,7 @@ _setUpArgumentParser(ArgumentParser & parser)
     addDescription(parser, "(c) Copyright 2009 by Tobias Rausch");
 
     addSection(parser, "Main Options:");
-    addOption(parser, ArgParseOption("s", "seq", "Name of multi-fasta input file.", ArgParseArgument::INPUTFILE));
+    addOption(parser, ArgParseOption("s", "seq", "Name of multi-fasta input file.", ArgParseArgument::INPUT_FILE));
     setValidValues(parser, "seq", getFileFormatExtensions(Fasta()));  // allow only fasta files as input
 
     addOption(parser, ArgParseOption("a", "alphabet", "The used sequence alphabet.", ArgParseArgument::STRING));
@@ -360,7 +360,7 @@ _setUpArgumentParser(ArgumentParser & parser)
     addOption(parser,
               ArgParseOption("l", "libraries", "Name of match file. "
                              "To select multiple files recall this option with different arguments.",
-                             ArgParseArgument::INPUTFILE, "", true));
+                             ArgParseArgument::INPUT_FILE, "", true));
     
     setValidValues(parser, "l", "blast mums aln lib");  // allow blast, mummer aln and tcoffee lib files
 
@@ -371,16 +371,16 @@ _setUpArgumentParser(ArgumentParser & parser)
       addOption(parser,
               ArgParseOption("mu", "mummer", "Name of \\fIMUMmer\\fP match file. "
                              "To select multiple \\fIMUMmer\\fP files recall this option with different arguments.",
-                             ArgParseArgument::INPUTFILE, "", true));
+                             ArgParseArgument::INPUT_FILE, "", true));
     addOption(parser,
               ArgParseOption("al", "aln", "Name of \\fIFASTA\\fP align file."
                              "To select multiple \\fIFASTA\\fP files recall this option with different arguments.",
-                             ArgParseArgument::INPUTFILE, "", true));
+                             ArgParseArgument::INPUT_FILE, "", true));
     addOption(
             parser,
             ArgParseOption("li", "lib", "Name of \\fIT-Coffee\\fP library. "
                            "To select multiple \\fIT-Coffee\\fP libraries recall this option with different arguments.",
-                           ArgParseArgument::INPUTFILE, "", true));
+                           ArgParseArgument::INPUT_FILE, "", true));
      */
 
     addSection(parser, "Scoring Options:");
@@ -418,7 +418,7 @@ _setUpArgumentParser(ArgumentParser & parser)
     addOption(
             parser,
             ArgParseOption("i", "infile", "Name of the alignment file <\\fIFASTA FILE\\fP>",
-                           ArgParseArgument::INPUTFILE));
+                           ArgParseArgument::INPUT_FILE));
     setValidValues(parser, "infile", getFileFormatExtensions(Fasta()));  // allow only fasta files as input
 
 }

--- a/core/apps/seqcons/seqcons.cpp
+++ b/core/apps/seqcons/seqcons.cpp
@@ -54,13 +54,13 @@ seqan::ArgumentParser::ParseResult parseCommandLine(ConsensusOptions & consOpt, 
 
 
 	addSection(parser, "Main Options:");
-	addOption(parser, ArgParseOption("r", "reads", "file with reads", ArgParseArgument::INPUTFILE, "<FASTA reads file>"));
+	addOption(parser, ArgParseOption("r", "reads", "file with reads", ArgParseArgument::INPUT_FILE, "<FASTA reads file>"));
     setValidValues(parser, "reads", "fa fasta");
-	addOption(parser, ArgParseOption("a", "afg", "message file", ArgParseArgument::INPUTFILE, "<AMOS afg file>"));
+	addOption(parser, ArgParseOption("a", "afg", "message file", ArgParseArgument::INPUT_FILE, "<AMOS afg file>"));
     setValidValues(parser, "afg", "afg");
-	addOption(parser, ArgParseOption("s", "sam", "Sam file", ArgParseArgument::INPUTFILE, "<Sam file>"));
+	addOption(parser, ArgParseOption("s", "sam", "Sam file", ArgParseArgument::INPUT_FILE, "<Sam file>"));
     setValidValues(parser, "s", "sam");
-	addOption(parser, ArgParseOption("c", "contigs", "FASTA file with contigs, ignored if not Sam input", ArgParseArgument::INPUTFILE, "<FASTA contigs file>"));
+	addOption(parser, ArgParseOption("c", "contigs", "FASTA file with contigs, ignored if not Sam input", ArgParseArgument::INPUT_FILE, "<FASTA contigs file>"));
     setValidValues(parser, "contigs", "fa fasta");
 	addOption(parser, ArgParseOption("o", "outfile", "output filename", ArgParseArgument::OUTPUTFILE, "<Filename>"));
 	setValidValues(parser, "outfile", "afg seqan cgb sam");

--- a/core/apps/snp_store/snp_store.cpp
+++ b/core/apps/snp_store/snp_store.cpp
@@ -1103,13 +1103,13 @@ parseCommandLine(SNPCallingOptions<TSpec> & options, int argc, char const ** arg
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIGENOME FILE\\fP> <\\fIALIGNMENT FILE\\fP> [<\\fIALIGNMENT FILE\\fP> ...]");
 
     // We require two mandatory arguments: genome file and read file(s)
-    addArgument(parser, ArgParseArgument(seqan::ArgParseArgument::INPUTFILE, "GENOME"));
+    addArgument(parser, ArgParseArgument(seqan::ArgParseArgument::INPUT_FILE, "GENOME"));
     setValidValues(parser, 0, ".fa .fasta");
     setHelpText(parser, 0, "A reference genome file.");
 
     std::vector<std::string> alignmentFormats(BamFileIn::getFileFormatExtensions());
     alignmentFormats.push_back(".gff");
-    addArgument(parser, ArgParseArgument(seqan::ArgParseArgument::INPUTFILE, "ALIGNMENTS", true));
+    addArgument(parser, ArgParseArgument(seqan::ArgParseArgument::INPUT_FILE, "ALIGNMENTS", true));
     setValidValues(parser, 1, alignmentFormats);
     setHelpText(parser, 1, "Read alignment file(s) sorted by genomic position.");
 

--- a/core/apps/splazers/splazers.cpp
+++ b/core/apps/splazers/splazers.cpp
@@ -315,10 +315,10 @@ int main(int argc, const char *argv[])
     setVersion(parser, "1.1");
     setDate(parser, "Apr 2011" );
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     setValidValues(parser, 0, seqan::SeqFileIn::getFileFormatExtensions());
     setHelpText(parser, 0, "A reference genome file.");
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "READS", true));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "READS", true));
     std::vector<std::string> exts = seqan::SeqFileIn::getFileFormatExtensions();
     exts.push_back(".sam");
     setValidValues(parser, 1, exts);

--- a/core/apps/stellar/stellar.cpp
+++ b/core/apps/stellar/stellar.cpp
@@ -500,9 +500,9 @@ void _setParser(ArgumentParser & parser)
                    "sequences from file 2 as queries.");
     addDescription(parser, "(c) 2010-2012 by Birte Kehr");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "FASTA FILE 1"));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "FASTA FILE 1"));
     setValidValues(parser, 0, "fa fasta");  // allow only fasta files as input
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "FASTA FILE 2"));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "FASTA FILE 2"));
     setValidValues(parser, 1, "fa fasta");  // allow only fasta files as input
 
     addSection(parser, "Main Options");

--- a/core/apps/tree_recon/tree_recon.cpp
+++ b/core/apps/tree_recon/tree_recon.cpp
@@ -99,7 +99,7 @@ int main(int argc, const char *argv[])
     addDescription(parser, "Reconstruct phylogenetic tree from Phylip matrix \\fIIN.DIST\\fP.");
 
 	addSection(parser, "Input / Output");
-    addOption(parser, seqan::ArgParseOption("m", "matrix", "Name Phylip distance matrix file.  Must contain at least three species.", seqan::ArgParseArgument::INPUTFILE, "FILE"));
+    addOption(parser, seqan::ArgParseOption("m", "matrix", "Name Phylip distance matrix file.  Must contain at least three species.", seqan::ArgParseArgument::INPUT_FILE, "FILE"));
     setRequired(parser, "matrix");
     setValidValues(parser, "matrix", "dist");
 	addOption(parser, seqan::ArgParseOption("o", "out-file", "Path to write output to.", seqan::ArgParseArgument::OUTPUTFILE, "FILE"));

--- a/core/apps/yara/indexer.cpp
+++ b/core/apps/yara/indexer.cpp
@@ -120,7 +120,7 @@ void setupArgumentParser(ArgumentParser & parser, Options const & /* options */)
 
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIREFERENCE FILE\\fP>");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     setValidValues(parser, 0, "fasta fa");
     setHelpText(parser, 0, "A reference genome file.");
 

--- a/core/apps/yara/mapper.cpp
+++ b/core/apps/yara/mapper.cpp
@@ -106,11 +106,11 @@ void setupArgumentParser(ArgumentParser & parser, Options const & options)
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIREFERENCE FILE\\fP> <\\fISE-READS FILE\\fP>");
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIREFERENCE FILE\\fP> <\\fIPE-READS FILE 1\\fP> <\\fIPE-READS FILE 2\\fP>");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     setValidValues(parser, 0, "fasta fa");
     setHelpText(parser, 0, "A reference genome file.");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "READS", true));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "READS", true));
     setValidValues(parser, 1, options.readsExtensionList);
     setHelpText(parser, 1, "Either one single-end or two paired-end / mate-pairs read files.");
 

--- a/core/demos/arg_parse/argument_parser.cpp
+++ b/core/demos/arg_parse/argument_parser.cpp
@@ -30,7 +30,7 @@ int main(int argc, char const ** argv)
             "txt output file.");
 
     // Add positional arguments and set their valid file types.
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "IN"));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "IN"));
     addArgument(parser, ArgParseArgument(ArgParseArgument::OUTPUTFILE, "OUT"));
     setValidValues(parser, 0, "FASTA fa");
     setValidValues(parser, 1, "txt");

--- a/core/demos/benchmark_stream.cpp
+++ b/core/demos/benchmark_stream.cpp
@@ -321,7 +321,7 @@ int main(int argc, char const ** argv)
     addOption(parser, ArgParseOption("n", "non-concat", "Do not use concat direct string for document-mmapped version."));
     addOption(parser, ArgParseOption("s", "multi-seq", "Use MultiSeqFile to read input."));
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "IN"));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "IN"));
 
     // -----------------------------------------------------------------------
     // Parse And Check Command Line Parameters

--- a/core/demos/knime_node.cpp
+++ b/core/demos/knime_node.cpp
@@ -87,7 +87,7 @@ parseCommandLine(KnimeNodeOptions & options, int argc, char const ** argv)
     addDescription(parser, "This is a very simple KNIME node providing an input and output port. The code should be modified such that the node does something useful");
     
     // We require one argument.
-    addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUTFILE, "IN"));
+    addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUT_FILE, "IN"));
     setValidValues(parser, 0, seqan::SeqFileIn::getFileFormatExtensions());
     
     addOption(parser, seqan::ArgParseOption("o", "outputFile", "Name of the multi-FASTA output.", seqan::ArgParseOption::OUTPUTFILE, "OUT"));
@@ -163,7 +163,7 @@ int main(int argc, char const ** argv)
         std::cout << "__OPTIONS____________________________________________________________________\n"
         << '\n'
         << "VERBOSITY\t" << options.verbosity << '\n'
-        << "INPUTFILE\t" << options.inputFile << "\n\n"
+        << "INPUT_FILE\t" << options.inputFile << "\n\n"
         << "OUTPUTFILE\t" << options.outputFile << "\n\n";
     }
     

--- a/core/demos/tutorial/rnaseq/genequant_assignment1.cpp
+++ b/core/demos/tutorial/rnaseq/genequant_assignment1.cpp
@@ -29,8 +29,8 @@ ArgumentParser::ParseResult parseOptions(Options & options, int argc, char const
     setVersion(parser, "1.0");
     setDate(parser, "Sep 2012");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIANNOTATION FILE\\fP> <\\fIREAD ALIGNMENT FILE\\fP>");
 
     // Parse command line

--- a/core/demos/tutorial/rnaseq/genequant_assignment2.cpp
+++ b/core/demos/tutorial/rnaseq/genequant_assignment2.cpp
@@ -34,8 +34,8 @@ ArgumentParser::ParseResult parseOptions(Options & options, int argc, char const
     setVersion(parser, "1.0");
     setDate(parser, "Sep 2012");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIANNOTATION FILE\\fP> <\\fIREAD ALIGNMENT FILE\\fP>");
 
     // Parse command line

--- a/core/demos/tutorial/rnaseq/genequant_assignment3.cpp
+++ b/core/demos/tutorial/rnaseq/genequant_assignment3.cpp
@@ -35,8 +35,8 @@ ArgumentParser::ParseResult parseOptions(Options & options, int argc, char const
     setVersion(parser, "1.0");
     setDate(parser, "Sep 2012");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIANNOTATION FILE\\fP> <\\fIREAD ALIGNMENT FILE\\fP>");
 
     // Parse command line

--- a/core/demos/tutorial/rnaseq/genequant_assignment4.cpp
+++ b/core/demos/tutorial/rnaseq/genequant_assignment4.cpp
@@ -36,8 +36,8 @@ ArgumentParser::ParseResult parseOptions(Options & options, int argc, char const
     setVersion(parser, "1.0");
     setDate(parser, "Sep 2012");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIANNOTATION FILE\\fP> <\\fIREAD ALIGNMENT FILE\\fP>");
 
     // Parse command line

--- a/core/demos/tutorial/rnaseq/genequant_assignment5.cpp
+++ b/core/demos/tutorial/rnaseq/genequant_assignment5.cpp
@@ -36,8 +36,8 @@ ArgumentParser::ParseResult parseOptions(Options & options, int argc, char const
     setVersion(parser, "1.0");
     setDate(parser, "Sep 2012");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIANNOTATION FILE\\fP> <\\fIREAD ALIGNMENT FILE\\fP>");
 
     // Parse command line

--- a/core/demos/tutorial/rnaseq/genequant_solution1.cpp
+++ b/core/demos/tutorial/rnaseq/genequant_solution1.cpp
@@ -29,8 +29,8 @@ ArgumentParser::ParseResult parseOptions(Options & options, int argc, char const
     setVersion(parser, "1.0");
     setDate(parser, "Sep 2012");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIANNOTATION FILE\\fP> <\\fIREAD ALIGNMENT FILE\\fP>");
 
     // Parse command line

--- a/core/demos/tutorial/rnaseq/genequant_solution2.cpp
+++ b/core/demos/tutorial/rnaseq/genequant_solution2.cpp
@@ -32,8 +32,8 @@ ArgumentParser::ParseResult parseOptions(Options & options, int argc, char const
     setVersion(parser, "1.0");
     setDate(parser, "Sep 2012");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIANNOTATION FILE\\fP> <\\fIREAD ALIGNMENT FILE\\fP>");
 
     // Parse command line

--- a/core/demos/tutorial/rnaseq/genequant_solution3.cpp
+++ b/core/demos/tutorial/rnaseq/genequant_solution3.cpp
@@ -33,8 +33,8 @@ ArgumentParser::ParseResult parseOptions(Options & options, int argc, char const
     setVersion(parser, "1.0");
     setDate(parser, "Sep 2012");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIANNOTATION FILE\\fP> <\\fIREAD ALIGNMENT FILE\\fP>");
 
     // Parse command line

--- a/core/demos/tutorial/rnaseq/genequant_solution4.cpp
+++ b/core/demos/tutorial/rnaseq/genequant_solution4.cpp
@@ -34,8 +34,8 @@ ArgumentParser::ParseResult parseOptions(Options & options, int argc, char const
     setVersion(parser, "1.0");
     setDate(parser, "Sep 2012");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIANNOTATION FILE\\fP> <\\fIREAD ALIGNMENT FILE\\fP>");
 
     // Parse command line

--- a/core/demos/tutorial/rnaseq/genequant_solution5.cpp
+++ b/core/demos/tutorial/rnaseq/genequant_solution5.cpp
@@ -34,8 +34,8 @@ ArgumentParser::ParseResult parseOptions(Options & options, int argc, char const
     setVersion(parser, "1.0");
     setDate(parser, "Sep 2012");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIANNOTATION FILE\\fP> <\\fIREAD ALIGNMENT FILE\\fP>");
 
     // Parse command line

--- a/core/include/seqan/arg_parse/arg_parse_argument.h
+++ b/core/include/seqan/arg_parse/arg_parse_argument.h
@@ -78,7 +78,7 @@ inline std::string getFileExtension(ArgParseArgument const & me, unsigned pos);
  *
  * @section Examples
  *
- * In the following example, the types <tt>INPUTFILE</tt>, <tt>OUTPUTFILE</tt>, and <tt>DOUBLE</tt> are used.
+ * In the following example, the types <tt>INPUT_FILE</tt>, <tt>OUTPUTFILE</tt>, and <tt>DOUBLE</tt> are used.
  *
  * @include demos/arg_parse/argument_parser.cpp
  */
@@ -96,7 +96,7 @@ inline std::string getFileExtension(ArgParseArgument const & me, unsigned pos);
  * @val ArgParseArgument::ArgumentType ArgParseArgument::DOUBLE;
  * @brief Argument is a floating point number stored as double.
  *
- * @val ArgParseArgument::ArgumentType ArgParseArgument::INPUTFILE;
+ * @val ArgParseArgument::ArgumentType ArgParseArgument::INPUT_FILE;
  * @brief Argument is an input file.
  *
  * @val ArgParseArgument::ArgumentType ArgParseArgument::OUTPUTFILE;
@@ -139,7 +139,7 @@ ArgParseArgument.
 ...table:$ArgParseArgument::INTEGER$|Argument is an integer
 ...table:$ArgParseArgument::INT64|Argument is a 64 bit integer
 ...table:$ArgParseArgument::DOUBLE$|A float
-...table:$ArgParseArgument::INPUTFILE$|An input file
+...table:$ArgParseArgument::INPUT_FILE$|An input file
 ...table:$ArgParseArgument::OUTPUTFILE$|An output file
  ..param.argumentLabel:Defines a user defined argument label for the help output. If this option is
  not set, ArgParseArgument will automatically define a label based on the ArgumentType.
@@ -161,7 +161,7 @@ public:
         INTEGER,     // .. an integer
         INT64,       // .. a 64 bit integer
         DOUBLE,      // .. a float
-        INPUTFILE,   // .. an inputfile (implicitly also a string)
+        INPUT_FILE,   // .. an inputfile (implicitly also a string)
         OUTPUTFILE,  // .. an outputfile (implicitly also a string)
         INPUTPREFIX, // .. an inputprefix (implicitly also a string)
         OUTPUTPREFIX // .. an outoutprefix (implicitly also a string)
@@ -256,7 +256,7 @@ inline std::string _typeToString(ArgParseArgument const & me)
         typeName = "string";
         break;
 
-    case ArgParseArgument::INPUTFILE:
+    case ArgParseArgument::INPUT_FILE:
         typeName = "inputfile";
         break;
 
@@ -348,7 +348,7 @@ inline bool isListArgument(ArgParseArgument const & me)
 inline bool isStringArgument(ArgParseArgument const & me)
 {
     return (me._argumentType == ArgParseArgument::STRING) ||
-           (me._argumentType == ArgParseArgument::INPUTFILE) ||
+           (me._argumentType == ArgParseArgument::INPUT_FILE) ||
            (me._argumentType == ArgParseArgument::OUTPUTFILE) ||
            (me._argumentType == ArgParseArgument::INPUTPREFIX) ||
            (me._argumentType == ArgParseArgument::OUTPUTPREFIX) ;
@@ -487,7 +487,7 @@ inline bool isDoubleArgument(ArgParseArgument const & me)
 
 inline bool isInputFileArgument(ArgParseArgument const & me)
 {
-    return me._argumentType == ArgParseArgument::INPUTFILE;
+    return me._argumentType == ArgParseArgument::INPUT_FILE;
 }
 
 // ----------------------------------------------------------------------------
@@ -816,11 +816,11 @@ inline void setMaxValue(ArgParseArgument & me, const std::string maxValue)
  * setValidValues(stringArg, values);  // one of {"four", "five"}
  * @endcode
  *
- * An example for an input file option.  Note that by changing <tt>INPUTFILE</tt> to <tt>OUTPUTFILE</tt> below,
+ * An example for an input file option.  Note that by changing <tt>INPUT_FILE</tt> to <tt>OUTPUTFILE</tt> below,
  * the example would be the same for output files.
  *
  * @code{.cpp}
- * seqan::ArgParseArgument fileArg(seqan::ArgParseArgument::INPUTFILE);
+ * seqan::ArgParseArgument fileArg(seqan::ArgParseArgument::INPUT_FILE);
  * setValidValues(fileArg, "fq fastq");  // file must end in ".fq" or ".fastq"
  *
  * std::vector<std::string> values;
@@ -1333,7 +1333,7 @@ inline unsigned numberOfAllowedValues(ArgParseArgument const & me)
  * @headerfile <seqan/arg_parse.h>
  * @brief Returns the file extension for the given file argument.
  *
- * Only valid when argument is an INPUTFILE or OUTPUTFILE.
+ * Only valid when argument is an INPUT_FILE or OUTPUTFILE.
  *
  * Halts the program if not an input or output file argument.
  *
@@ -1353,7 +1353,7 @@ inline unsigned numberOfAllowedValues(ArgParseArgument const & me)
 .Function.ArgParseArgument#getFileExtension
 ..class:Class.ArgParseArgument
 ..summary:Returns the file extension for the given file argument.
-..description:Only valid when argument is an INPUTFILE or OUTPUTFILE.
+..description:Only valid when argument is an INPUT_FILE or OUTPUTFILE.
 ..cat:Miscellaenous
 ..signature:std::string getFileExtension(argument[, pos]);
 ..param.argument:The @Class.ArgParseArgument@ object.
@@ -1368,7 +1368,7 @@ inline unsigned numberOfAllowedValues(ArgParseArgument const & me)
 
 inline std::string getFileExtension(ArgParseArgument const & me, unsigned pos = 0)
 {
-    if (me._argumentType != ArgParseArgument::INPUTFILE &&
+    if (me._argumentType != ArgParseArgument::INPUT_FILE &&
         me._argumentType != ArgParseArgument::OUTPUTFILE)
         SEQAN_FAIL("Cannot get file extension from non-file argument/option.");
 

--- a/core/include/seqan/arg_parse/argument_parser.h
+++ b/core/include/seqan/arg_parse/argument_parser.h
@@ -168,7 +168,7 @@ addDescription(parser,
                "based on k-mer counts.");
 
 addOption(parser, ArgParseOption("i", "inputFile", "Name of the multi-FASTA input.",
-                                 ArgParseArgument(ArgParseArgument::INPUTFILE, "IN")));
+                                 ArgParseArgument(ArgParseArgument::INPUT_FILE, "IN")));
 setRequired(parser, "i");
 
 addOption(parser, ArgParseOption("o", "outputFile", "Name of the multi-FASTA input.",
@@ -849,7 +849,7 @@ inline bool getOptionValue(TValue & val,
  *
  * @section Overriding File Extension on the Command Line
  *
- * For each option with type <tt>INPUTFILE</tt> and <tt>OUTPUTFILE</tt>, an option with the name
+ * For each option with type <tt>INPUT_FILE</tt> and <tt>OUTPUTFILE</tt>, an option with the name
  * <tt>${name}-file-ext</tt> is automatically added to the ArgumentParser (where <tt>${name}</tt> is the name
  * of the original option).  The extension can be overridden by specifying the argument.  Thus, the user of
  * the program could give the value "file.ext" to the parameter "fname" and override the extension on the
@@ -1035,7 +1035,7 @@ inline bool getArgumentValue(TValue & value,
  *
  * @section Overriding File Extensions on the Command Line
  *
- * For each argument with type <tt>INPUTFILE</tt> and <tt>OUTPUTFILE</tt>, an option with the index
+ * For each argument with type <tt>INPUT_FILE</tt> and <tt>OUTPUTFILE</tt>, an option with the index
  * <tt>arg-${idx}-file-ext</tt> is automatically added to the ArgumentParser (where <tt>${idx}</tt> is the index
  * of the original option).  The extension can be overridden by specifying the argument.  Thus, the user of
  * the program could give the value "file.ext" to the parameter "0" and override the extension on the

--- a/core/include/seqan/misc/cmdparser/cmdoption.h
+++ b/core/include/seqan/misc/cmdparser/cmdoption.h
@@ -59,7 +59,7 @@ struct OptionType
         Label = 32,                 // automatically print a label for the argument(s) on the help screen
         List = 64,                  // option is a list of values
         Hidden = 128,               // hide this option from the help screen
-        INPUTFILE = 256,            // this option is an input file .. is implicitly also a string, since paths/filenames are strings
+        INPUT_FILE = 256,            // this option is an input file .. is implicitly also a string, since paths/filenames are strings
         OUTPUTFILE = 512            // this option is an output file .. is implicitly also a string, since paths/filenames are strings
     };
 };
@@ -103,7 +103,7 @@ Although not suggested the short-name can contain more than 1 character.
 ...table:$OptionType::Label$|32|Automatically print a label for the argument(s) on the help screen
 ...table:$OptionType::List$|64|Option is a list of values
 ...table:$OptionType::Hidden$|128|Hide this option from the help screen
-...table:$OptionType::INPUTFILE$|256|Argument is an input file
+...table:$OptionType::INPUT_FILE$|256|Argument is an input file
 ...table:$OptionType::OUTPUTFILE$|512|Argument is an output file
 ..param.defaultValue:The default value of this option.
 ...default:No default value.
@@ -259,7 +259,7 @@ addArgumentText(CommandLineOption const & opt, CharString const & text)
 inline bool
 isStringOption(CommandLineOption const & me)
 {
-    return (me.optionType & (OptionType::String | OptionType::INPUTFILE | OptionType::OUTPUTFILE)) != 0;
+    return (me.optionType & (OptionType::String | OptionType::INPUT_FILE | OptionType::OUTPUTFILE)) != 0;
 }
 
 // ----------------------------------------------------------------------------
@@ -435,7 +435,7 @@ isOptionList(CommandLineOption const & me)
 inline bool
 isInputFile(CommandLineOption const & me)
 {
-    return (me.optionType & OptionType::INPUTFILE) != 0;
+    return (me.optionType & OptionType::INPUT_FILE) != 0;
 }
 
 // ----------------------------------------------------------------------------

--- a/core/tests/arg_parse/test_arg_parse.h
+++ b/core/tests/arg_parse/test_arg_parse.h
@@ -140,7 +140,7 @@ void setupStringParser(ArgumentParser & parser)
 
 void setupInputFileParser(ArgumentParser & parser)
 {
-    addOption(parser, ArgParseOption("i", "in", "set an input file", ArgParseArgument::INPUTFILE));
+    addOption(parser, ArgParseOption("i", "in", "set an input file", ArgParseArgument::INPUT_FILE));
 }
 
 void setupOutputFileParser(ArgumentParser & parser)
@@ -755,7 +755,7 @@ SEQAN_DEFINE_TEST(test_input_file_auto_file_ext_option)
     {
         ArgumentParser parser;
 
-        addOption(parser, ArgParseOption("short", "long", "help text", ArgParseOption::INPUTFILE));
+        addOption(parser, ArgParseOption("short", "long", "help text", ArgParseOption::INPUT_FILE));
         setValidValues(parser, "long", ".fa .TXT");
 
         SEQAN_ASSERT_NOT(hasOption(parser, "short-file-ext"));
@@ -772,7 +772,7 @@ SEQAN_DEFINE_TEST(test_input_file_auto_file_ext_option)
     {
         ArgumentParser parser;
 
-        addOption(parser, ArgParseOption("short", "long", "help text", ArgParseOption::INPUTFILE,
+        addOption(parser, ArgParseOption("short", "long", "help text", ArgParseOption::INPUT_FILE,
                                          "label", false, 2));
         setValidValues(parser, "long", ".fa .TXT");
 
@@ -790,7 +790,7 @@ SEQAN_DEFINE_TEST(test_input_file_auto_file_ext_option)
     {
         ArgumentParser parser;
 
-        addOption(parser, ArgParseOption("short", "long", "help text", ArgParseOption::INPUTFILE,
+        addOption(parser, ArgParseOption("short", "long", "help text", ArgParseOption::INPUT_FILE,
                                          "label", true));
         setValidValues(parser, "long", ".fa .TXT");
 
@@ -1066,7 +1066,7 @@ SEQAN_DEFINE_TEST(test_argument_auto_file_ext_option)
     // No list, one value.
     {
         ArgumentParser parser;
-        addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+        addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
         setValidValues(parser, 0, "fa TXT");
 
         SEQAN_ASSERT(hasOption(parser, "arg-1-file-ext"));
@@ -1083,7 +1083,7 @@ SEQAN_DEFINE_TEST(test_argument_auto_file_ext_option)
     // List, one value.
     {
         ArgumentParser parser;
-        addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "LABEL", true));
+        addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "LABEL", true));
         setValidValues(parser, 0, "fa TXT");
 
         SEQAN_ASSERT(hasOption(parser, "arg-1-file-ext"));
@@ -1099,7 +1099,7 @@ SEQAN_DEFINE_TEST(test_argument_auto_file_ext_option)
     {
         ArgumentParser parser;
         addArgument(parser, ArgParseArgument(ArgParseArgument::DOUBLE));
-        addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+        addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
         setValidValues(parser, 1, "fa TXT");
 
         SEQAN_ASSERT(hasOption(parser, "arg-2-file-ext"));

--- a/core/tests/arg_parse/test_arg_parse_argument.h
+++ b/core/tests/arg_parse/test_arg_parse_argument.h
@@ -82,13 +82,13 @@ SEQAN_DEFINE_TEST(test_argument_double_label)
 
 SEQAN_DEFINE_TEST(test_argument_inputfile_label)
 {
-    ArgParseArgument arg1(ArgParseArgument::INPUTFILE);
+    ArgParseArgument arg1(ArgParseArgument::INPUT_FILE);
     SEQAN_ASSERT_EQ(getArgumentLabel(arg1), "FILE");
 
     arg1._numberOfValues = 2;
     SEQAN_ASSERT_EQ(getArgumentLabel(arg1), "FILE FILE");
 
-    ArgParseArgument arg2(ArgParseArgument::INPUTFILE);
+    ArgParseArgument arg2(ArgParseArgument::INPUT_FILE);
     SEQAN_ASSERT_EQ(getArgumentLabel(arg2), "FILE");
 }
 
@@ -189,7 +189,7 @@ SEQAN_DEFINE_TEST(test_argument_valid_values)
                          _checkValue(arg),
                          "the given value 'not-this-or-that' is not in the list of allowed values [this, that]");
 
-    ArgParseArgument filearg(ArgParseArgument::INPUTFILE);
+    ArgParseArgument filearg(ArgParseArgument::INPUT_FILE);
     setValidValues(filearg, ".txt .fasta");
 
     _assignArgumentValue(filearg, "textfile.txt");

--- a/core/tests/arg_parse/test_arg_parse_ctd_support.h
+++ b/core/tests/arg_parse/test_arg_parse_ctd_support.h
@@ -62,7 +62,7 @@ SEQAN_DEFINE_TEST(test_arg_parse_ctd_support)
     addOption(parser, seqan::ArgParseOption("j", "int64", "set a 64 bit integer option", seqan::ArgParseArgument::INT64));
     addOption(parser, seqan::ArgParseOption("s", "string", "set a string option", seqan::ArgParseArgument::STRING, "", true));
     setValidValues(parser, "s", "a b c");
-    addOption(parser, seqan::ArgParseOption("f", "in", "set an input file", seqan::ArgParseArgument::INPUTFILE));
+    addOption(parser, seqan::ArgParseOption("f", "in", "set an input file", seqan::ArgParseArgument::INPUT_FILE));
     setValidValues(parser, "f", "fasta");
     addOption(parser, seqan::ArgParseOption("o", "out", "set an output file", seqan::ArgParseArgument::OUTPUTFILE));
     setValidValues(parser, "o", "sam");

--- a/core/tests/misc/test_misc_cmdparser.cpp
+++ b/core/tests/misc/test_misc_cmdparser.cpp
@@ -104,7 +104,7 @@ void testInitStringParser(CommandLineParser & parser)
 
 void testInFileTypeParser(CommandLineParser & parser)
 {
-    addOption(parser, CommandLineOption("i", "in", "set a input file", OptionType::Label | OptionType::INPUTFILE));
+    addOption(parser, CommandLineOption("i", "in", "set a input file", OptionType::Label | OptionType::INPUT_FILE));
 }
 
 void testOutFileTypeParser(CommandLineParser & parser)

--- a/extras/apps/alf/alf.cpp
+++ b/extras/apps/alf/alf.cpp
@@ -73,7 +73,7 @@ int main(int argc, const char * argv[])
 
     // Options Section: Input / Output parameters.
     addSection(parser, "Input / Output");
-    addOption(parser, seqan::ArgParseOption("i", "input-file", "Name of the multi-FASTA input file.", seqan::ArgParseArgument::INPUTFILE));
+    addOption(parser, seqan::ArgParseOption("i", "input-file", "Name of the multi-FASTA input file.", seqan::ArgParseArgument::INPUT_FILE));
     setValidValues(parser, "input-file", "fa fasta");
     setRequired(parser, "input-file");
     addOption(parser, seqan::ArgParseOption("o", "output-file", "Name of the file to which the tab-delimtied matrix with pairwise scores will be written to.  Default is to write to stdout.", seqan::ArgParseArgument::OUTPUTFILE));

--- a/extras/apps/breakpoint_calculator/breakpoint_calculator.h
+++ b/extras/apps/breakpoint_calculator/breakpoint_calculator.h
@@ -116,7 +116,7 @@ setupCommandLineParser(ArgumentParser & parser)
                    "is guessed from the file extension.");
     addDescription(parser, "(c) 2012 by Birte Kehr");
     
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "ALIGNMENTFILE"));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "ALIGNMENTFILE"));
     //setValidValues(parser, 0, "xmfa maf"); // allow only *.xmfa and *.maf files as input
 
     addSection(parser, "Main Options");

--- a/extras/apps/bs_tools/bisar.cpp
+++ b/extras/apps/bs_tools/bisar.cpp
@@ -146,13 +146,13 @@ parseCommandLine(AppOptions & options, int argc, char const ** argv)
     addDescription(parser, "This program reads three-letter mappings of bisulfite reads and computes local pairwise four-letter realignments using an advanced statistical alignment model.");
 
     // We require ... arguments.
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "ALIGNMENTS"));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "ALIGNMENTS"));
     setHelpText(parser, 0, "SAM input file containing three-letter read alignments (must be sorted by query names).");
     setValidValues(parser, 0, BamFileIn::getFileFormatExtensions());
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "GENOME"));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "GENOME"));
     setHelpText(parser, 1, "A reference genome file.");
     setValidValues(parser, 1, SeqFileIn::getFileFormatExtensions());
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "READS", true));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "READS", true));
     setHelpText(parser, 2, "Either one (single-end) or two (paired-end) read files.");
     setValidValues(parser, 2, SeqFileIn::getFileFormatExtensions());
 

--- a/extras/apps/bs_tools/casbar.cpp
+++ b/extras/apps/bs_tools/casbar.cpp
@@ -1008,10 +1008,10 @@ parseCommandLine(SNPCallingOptions & options, TMethOptions &methOptions, int arg
     addDescription(parser, "SNP and methylation level calling in mapped bisulfite read data.");
 
     // We require two arguments.
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "GENOME"));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "GENOME"));
     setValidValues(parser, 0, SeqFileIn::getFileFormatExtensions());
     setHelpText(parser, 0, "A reference genome file.");
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "ALIGNMENTS"));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "ALIGNMENTS"));
     setValidValues(parser, 1, BamFileIn::getFileFormatExtensions());
     setHelpText(parser, 1, "SAM input file containing four-letter read alignments (must be sorted by coordinates).");
 

--- a/extras/apps/bs_tools/four2three.cpp
+++ b/extras/apps/bs_tools/four2three.cpp
@@ -73,7 +73,7 @@ parseCommandLine(AppOptions & options, int argc, char const ** argv)
     addUsageLine(parser, "[\\fIOPTIONS\\fP] \"\\fISEQUENCE FILE\\fP\"");
     addDescription(parser, "This program converts four-letter sequences into three-letter sequences for bisulfite sequence analysis.");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "SEQUENCES"));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "SEQUENCES"));
     setHelpText(parser, 0, "A sequence file containing reads or genome.");
     setValidValues(parser, 0, SeqFileIn::getFileFormatExtensions());
 

--- a/extras/apps/fx_tools/fx_bam_coverage.cpp
+++ b/extras/apps/fx_tools/fx_bam_coverage.cpp
@@ -110,12 +110,12 @@ parseArgs(FxBamCoverageOptions & options,
 
     // Two input files: Genome, and mapping.
     addOption(parser, seqan::ArgParseOption("r", "in-reference", "Path to the reference file.",
-                                            seqan::ArgParseArgument::INPUTFILE, "IN.fa"));
+                                            seqan::ArgParseArgument::INPUT_FILE, "IN.fa"));
     setValidValues(parser, "in-reference", "fasta fa");
     setRequired(parser, "in-reference");
 
     addOption(parser, seqan::ArgParseOption("m", "in-mapping", "Path to the mapping file to analyze.",
-                                            seqan::ArgParseArgument::INPUTFILE));
+                                            seqan::ArgParseArgument::INPUT_FILE));
     setValidValues(parser, "in-mapping", "sam bam");
     setRequired(parser, "in-mapping");
 

--- a/extras/apps/fx_tools/fx_fastq_stats.cpp
+++ b/extras/apps/fx_tools/fx_fastq_stats.cpp
@@ -249,7 +249,7 @@ parseCommandLine(AppOptions & options, int argc, char const ** argv)
                    "each column/position with statistics on the nucleotides and qualities.");
 
     addSection(parser, "Input / Output");
-    addOption(parser, seqan::ArgParseOption("i", "input", "Input FASTQ file.", seqan::ArgParseOption::INPUTFILE, "INPUT"));
+    addOption(parser, seqan::ArgParseOption("i", "input", "Input FASTQ file.", seqan::ArgParseOption::INPUT_FILE, "INPUT"));
     setValidValues(parser, "input", "fastq fq");
     setRequired(parser, "input");
     addOption(parser, seqan::ArgParseOption("o", "output", "Output TSV file.", seqan::ArgParseOption::OUTPUTFILE, "OUTPUT"));

--- a/extras/apps/gustaf/join_mates.cpp
+++ b/extras/apps/gustaf/join_mates.cpp
@@ -107,10 +107,10 @@ parseCommandLine(JoinMatesOptions & options, int argc, char const ** argv)
         "-rc -o adeno_modified_reads_joinedMates.fa");
 
     // We require two arguments.
-    addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUTFILE, "FASTA/FASTQ FILE(S)", true));
+    addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUT_FILE, "FASTA/FASTQ FILE(S)", true));
     setValidValues(parser, 0, "fa fasta fq fastq");
     /*
-    addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUTFILE, "FASTA/FASTQ FILE 2"));
+    addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUT_FILE, "FASTA/FASTQ FILE 2"));
     setValidValues(parser, 1, "fasta fa fastq fq");
     */
 

--- a/extras/apps/gustaf/msplazer_parse_options.h
+++ b/extras/apps/gustaf/msplazer_parse_options.h
@@ -154,14 +154,14 @@ void _setupArgumentParser(ArgumentParser & parser)
 
     addSection(parser, "GUSTAF Options");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "FASTA FILE 1"));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "FASTA FILE 1"));
     setValidValues(parser, 0, "fa fasta fq fastq");  // allow only fasta/q files as input
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "FASTA FILE 2", true));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "FASTA FILE 2", true));
     setValidValues(parser, 1, "fa fasta fq fastq");  // allow only fasta/q files as input
     setHelpText(parser, 1, "Either one (single-end) or two (paired-end) read files.");
 
 
-    addSection(parser, "Main Options");  // addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "FASTA FILE 3"));
+    addSection(parser, "Main Options");  // addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "FASTA FILE 3"));
     // setValidValues(parser, 2, "fa fasta");  // allow only fasta files as input
 
     addOption(parser,
@@ -208,7 +208,7 @@ void _setupArgumentParser(ArgumentParser & parser)
     // set min values?
 
     addSection(parser, "Input Options");
-    addOption(parser, ArgParseOption("m", "matchfile", "File of (stellar) matches", ArgParseArgument::INPUTFILE, "FILE"));
+    addOption(parser, ArgParseOption("m", "matchfile", "File of (stellar) matches", ArgParseArgument::INPUT_FILE, "FILE"));
     setValidValues(parser, "m", "gff GFF");
 
     addSection(parser, "Output Options");

--- a/extras/apps/insegt/insegt.cpp
+++ b/extras/apps/insegt/insegt.cpp
@@ -81,9 +81,9 @@ parseCommandLine(InsegtOptions & options, int argc, char const ** argv)
     // We require two arguments.
     addDescription(parser, "Input to INSEGT is a SAM file containing the alignments and"
                           " a file containing the annotations of the reference genome, either in GFF or GTF format.");
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     setValidValues(parser, 0, "sam");
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     setValidValues(parser, 1, "gff gtf");
     // Define Options -- Section Modification Options
 

--- a/extras/apps/mason2/mason_options.cpp
+++ b/extras/apps/mason2/mason_options.cpp
@@ -334,12 +334,12 @@ void MaterializerOptions::addOptions(seqan::ArgumentParser & parser) const
     addSection(parser, "Apply VCF Variants to Reference");
 
     addOption(parser, seqan::ArgParseOption("ir", "input-reference", "Path to FASTA file to read the reference from.",
-                                            seqan::ArgParseOption::INPUTFILE, "IN.fa"));
+                                            seqan::ArgParseOption::INPUT_FILE, "IN.fa"));
     setValidValues(parser, "input-reference", "fa fasta");
     setRequired(parser, "input-reference");
 
     addOption(parser, seqan::ArgParseOption("iv", "input-vcf", "Path to the VCF file with variants to apply.",
-                                            seqan::ArgParseOption::INPUTFILE, "IN.vcf"));
+                                            seqan::ArgParseOption::INPUT_FILE, "IN.vcf"));
     setValidValues(parser, "input-vcf", "vcf");
 }
 
@@ -606,7 +606,7 @@ void IlluminaSequencingOptions::addOptions(seqan::ArgumentParser & parser) const
                                             "Path to file with Illumina error profile.  The file must be a text file "
                                             "with floating point numbers separated by space, each giving a positional "
                                             "error rate.",
-                                            seqan::ArgParseOption::INPUTFILE, "FILE"));
+                                            seqan::ArgParseOption::INPUT_FILE, "FILE"));
     setValidValues(parser, "illumina-error-profile-file", "txt");
 
     addOption(parser, seqan::ArgParseOption("", "illumina-prob-insert",
@@ -699,12 +699,12 @@ void IlluminaSequencingOptions::addOptions(seqan::ArgumentParser & parser) const
 
     addOption(parser, seqan::ArgParseOption("", "illumina-left-template-fastq",
                                             "FASTQ file to use for a template for left-end reads.",
-                                            seqan::ArgParseOption::INPUTFILE, "IN.fq"));
+                                            seqan::ArgParseOption::INPUT_FILE, "IN.fq"));
     setValidValues(parser, "illumina-left-template-fastq", "fq fastq fq.gz fastq.gz");
 
     addOption(parser, seqan::ArgParseOption("", "illumina-right-template-fastq",
                                             "FASTQ file to use for a template for right-end reads.",
-                                            seqan::ArgParseOption::INPUTFILE, "IN.fq"));
+                                            seqan::ArgParseOption::INPUT_FILE, "IN.fq"));
     setValidValues(parser, "illumina-right-template-fastq", "fq fastq fq.gz fastq.gz");
 }
 
@@ -1112,7 +1112,7 @@ void MasonSimulatorOptions::addOptions(seqan::ArgumentParser & parser) const
     setMinValue(parser, "num-fragments", "1");
 
     addOption(parser, seqan::ArgParseOption("", "meth-fasta-in", "FASTA file with methylation levels of the input file.",
-                                            seqan::ArgParseOption::INPUTFILE, "IN"));
+                                            seqan::ArgParseOption::INPUT_FILE, "IN"));
     setValidValues(parser, "meth-fasta-in", "fa fasta");
 
     addOption(parser, seqan::ArgParseOption("o", "out", "Output of single-end/left end reads.",
@@ -1327,7 +1327,7 @@ void MasonMaterializerOptions::addOptions(seqan::ArgumentParser & parser) const
     setDefaultValue(parser, "haplotype-name-sep", "/");
 
     addOption(parser, seqan::ArgParseOption("", "meth-fasta-in", "FASTA file with methylation levels of the input file.",
-                                            seqan::ArgParseOption::INPUTFILE, "IN"));
+                                            seqan::ArgParseOption::INPUT_FILE, "IN"));
     setValidValues(parser, "meth-fasta-in", "fa fasta");
 
     addOption(parser, seqan::ArgParseOption("", "meth-fasta-out", "FASTA file with methylation levels of the output file.",
@@ -1438,16 +1438,16 @@ void MasonSplicingOptions::addOptions(seqan::ArgumentParser & parser) const
 
     addOption(parser, seqan::ArgParseOption("ig", "in-gff", "Path to input GFF or GTF file, must be "
                                             "sorted by reference name.",
-                                            seqan::ArgParseOption::INPUTFILE, "IN.gff"));
+                                            seqan::ArgParseOption::INPUT_FILE, "IN.gff"));
     setValidValues(parser, "in-gff", "gff gtf");
     setRequired(parser, "in-gff");
 
     addOption(parser, seqan::ArgParseOption("", "gff-type", "Splicing will filter to the records that have this type.",
-                                            seqan::ArgParseOption::INPUTFILE, "TYPE"));
+                                            seqan::ArgParseOption::INPUT_FILE, "TYPE"));
     setDefaultValue(parser, "gff-type", "exon");
 
     addOption(parser, seqan::ArgParseOption("", "gff-group-by", "Assign features to their parent using the tag "
-                                            "with this name.", seqan::ArgParseOption::INPUTFILE, "KEY"));
+                                            "with this name.", seqan::ArgParseOption::INPUT_FILE, "KEY"));
     setDefaultValue(parser, "gff-group-by", "Parent");
 
     // Add options of the component options.
@@ -1533,7 +1533,7 @@ void MasonFragmentSequencingOptions::addOptions(seqan::ArgumentParser & parser) 
     setDefaultValue(parser, "seed", "0");
 
     addOption(parser, seqan::ArgParseOption("i", "in", "Path to input file.",
-                                            seqan::ArgParseOption::INPUTFILE, "OUT"));
+                                            seqan::ArgParseOption::INPUT_FILE, "OUT"));
     setRequired(parser, "in");
     setValidValues(parser, "in", "fa fasta");
 
@@ -1649,12 +1649,12 @@ void MasonMethylationOptions::addOptions(seqan::ArgumentParser & parser) const
     setDefaultValue(parser, "seed", "0");
 
     addOption(parser, seqan::ArgParseOption("i", "in", "Input FASTA file with genome.",
-                                            seqan::ArgParseOption::INPUTFILE, "IN.fa"));
+                                            seqan::ArgParseOption::INPUT_FILE, "IN.fa"));
     setRequired(parser, "in");
     setValidValues(parser, "in", "fa fasta");
 
     addOption(parser, seqan::ArgParseOption("o", "out", "Input FASTA file with genome.",
-                                            seqan::ArgParseOption::INPUTFILE, "OUT.fa"));
+                                            seqan::ArgParseOption::INPUT_FILE, "OUT.fa"));
     setRequired(parser, "out");
     setValidValues(parser, "out", "fa fasta");
 

--- a/extras/apps/mason2/mason_variator.cpp
+++ b/extras/apps/mason2/mason_variator.cpp
@@ -1682,26 +1682,26 @@ parseCommandLine(MasonVariatorOptions & options, int argc, char const ** argv)
     addSection(parser, "Input / Output");
 
     // addOption(parser, seqan::ArgParseOption("iv", "in-vcf", "VCF file to load variations from.",
-    //                                         seqan::ArgParseOption::INPUTFILE, "VCF"));
+    //                                         seqan::ArgParseOption::INPUT_FILE, "VCF"));
     // setValidValues(parser, "in-vcf", "vcf");
 
     addOption(parser, seqan::ArgParseOption("ir", "in-reference", "FASTA file with reference.",
-                                            seqan::ArgParseOption::INPUTFILE, "FASTA"));
+                                            seqan::ArgParseOption::INPUT_FILE, "FASTA"));
     setValidValues(parser, "in-reference", "fasta fa");
     setRequired(parser, "in-reference");
 
     addOption(parser, seqan::ArgParseOption("it", "in-variant-tsv",
                                             "TSV file with variants to simulate.  See Section on the Variant TSV File below.",
-                                            seqan::ArgParseOption::INPUTFILE, "VCF"));
+                                            seqan::ArgParseOption::INPUT_FILE, "VCF"));
     setValidValues(parser, "in-variant-tsv", "tsv txt");
 
     addOption(parser, seqan::ArgParseOption("ov", "out-vcf", "VCF file to write simulated variations to.",
-                                            seqan::ArgParseOption::INPUTFILE, "VCF"));
+                                            seqan::ArgParseOption::INPUT_FILE, "VCF"));
     setRequired(parser, "out-vcf");
     setValidValues(parser, "out-vcf", "vcf");
 
     addOption(parser, seqan::ArgParseOption("of", "out-fasta", "FASTA file to write simulated haplotypes to.",
-                                            seqan::ArgParseOption::INPUTFILE, "FASTA"));
+                                            seqan::ArgParseOption::INPUT_FILE, "FASTA"));
     setValidValues(parser, "out-fasta", "fasta fa");
 
     addOption(parser, seqan::ArgParseOption("", "out-breakpoints", "TSV file to write breakpoints in variants to.",
@@ -1801,7 +1801,7 @@ parseCommandLine(MasonVariatorOptions & options, int argc, char const ** argv)
 
     addOption(parser, seqan::ArgParseOption("", "meth-fasta-in", "Path to load original methylation levels from.  "
                                             "Methylation levels are simulated if omitted.",
-                                            seqan::ArgParseOption::INPUTFILE, "FILE"));
+                                            seqan::ArgParseOption::INPUT_FILE, "FILE"));
     setValidValues(parser, "meth-fasta-in", "fa fasta");
 
     addOption(parser, seqan::ArgParseOption("", "meth-fasta-out", "Path to write methylation levels to as FASTA.  "

--- a/extras/apps/ngs_roi/bam2roi.cpp
+++ b/extras/apps/ngs_roi/bam2roi.cpp
@@ -166,7 +166,7 @@ parseCommandLine(Options & options, int argc, char const ** argv)
     addSection(parser, "Input / Output Parameters");
 
     addOption(parser, seqan::ArgParseOption("if", "input-file", "SAM/BAM formatted file.  Must be sorted by coordinate.",
-                                            seqan::ArgParseOption::INPUTFILE));
+                                            seqan::ArgParseOption::INPUT_FILE));
     setValidValues(parser, "input-file", seqan::BamFileIn::getFileFormatExtensions());
     setRequired(parser, "input-file");
 

--- a/extras/apps/ngs_roi/roi_feature_projection.cpp
+++ b/extras/apps/ngs_roi/roi_feature_projection.cpp
@@ -681,11 +681,11 @@ parseCommandLine(RoiIntersectOptions & options, int argc, char const ** argv)
 
     addSection(parser, "Input / Output");
 
-    addOption(parser, seqan::ArgParseOption("ir", "in-roi", "ROI file to read.", seqan::ArgParseOption::INPUTFILE, "ROI"));
+    addOption(parser, seqan::ArgParseOption("ir", "in-roi", "ROI file to read.", seqan::ArgParseOption::INPUT_FILE, "ROI"));
     setRequired(parser, "in-roi");
     setValidValues(parser, "in-roi", seqan::RoiFileIn::getFileFormatExtensions());
 
-    addOption(parser, seqan::ArgParseOption("if", "in-features", "BED, GFF, or GTF file to read.", seqan::ArgParseOption::INPUTFILE, "FILE"));
+    addOption(parser, seqan::ArgParseOption("if", "in-features", "BED, GFF, or GTF file to read.", seqan::ArgParseOption::INPUT_FILE, "FILE"));
     setRequired(parser, "in-features");
     std::vector<std::string> extensions = seqan::BedFileIn::getFileFormatExtensions();
     std::vector<std::string> extensionsGff = seqan::GffFileIn::getFileFormatExtensions();
@@ -699,7 +699,7 @@ parseCommandLine(RoiIntersectOptions & options, int argc, char const ** argv)
     addOption(parser, seqan::ArgParseOption("g", "genome",
                                             "Path to FASTA file with genome; optional.  When given, this is used for "
                                             "computing the overall region's C+G content.",
-                                            seqan::ArgParseOption::INPUTFILE, "FASTA"));
+                                            seqan::ArgParseOption::INPUT_FILE, "FASTA"));
     setValidValues(parser, "genome", "fasta fa");
 
     // -----------------------------------------------------------------------

--- a/extras/apps/ngs_roi/roi_plot_thumbnails.cpp
+++ b/extras/apps/ngs_roi/roi_plot_thumbnails.cpp
@@ -311,7 +311,7 @@ parseCommandLine(Options & options, int argc, char const ** argv)
     addSection(parser, "Input / Output Parameters");
 
     addOption(parser, seqan::ArgParseOption("if", "input-file", "ROI to plot.",
-                                            seqan::ArgParseOption::INPUTFILE));
+                                            seqan::ArgParseOption::INPUT_FILE));
     setValidValues(parser, "input-file", seqan::RoiFileIn::getFileFormatExtensions());
     setRequired(parser, "input-file");
 

--- a/extras/apps/razers3/razers.cpp
+++ b/extras/apps/razers3/razers.cpp
@@ -311,10 +311,10 @@ void setUpArgumentParser(ArgumentParser & parser, RazerSOptions<> & options, Par
 	setVersion(parser, options.version);
 
     // Need genome and reads (hg18.fa reads.fq)
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     setValidValues(parser, 0, seqan::SeqFileIn::getFileFormatExtensions());
     setHelpText(parser, 0, "A reference genome file.");
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "READS", true));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "READS", true));
     setValidValues(parser, 1, seqan::SeqFileIn::getFileFormatExtensions());
     setHelpText(parser, 1, "Either one (single-end) or two (paired-end) read files.");
 

--- a/extras/apps/rep_sep/rep_sep.cpp
+++ b/extras/apps/rep_sep/rep_sep.cpp
@@ -76,7 +76,7 @@ parseCommandLine(RepSepOptions & options, int argc, char const ** argv)
     setShortDescription(parser, "Repeat Seperation Tool -- Copyright (c) 2009, Stephan Aiche");
 
     // needed input file
-    addOption(parser, ArgParseOption("a", "assembly", "Input assembly filename.", ArgParseArgument::INPUTFILE));
+    addOption(parser, ArgParseOption("a", "assembly", "Input assembly filename.", ArgParseArgument::INPUT_FILE));
     setValidValues(parser, "assembly", "afg");
     setRequired(parser, "assembly");
 

--- a/extras/apps/searchjoin/join.cpp
+++ b/extras/apps/searchjoin/join.cpp
@@ -114,7 +114,7 @@ void setupArgumentParser(ArgumentParser & parser)
 
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIDATABASE FILE\\fP> <\\fIERRORS\\fP>");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
     addArgument(parser, ArgParseArgument(ArgParseArgument::INTEGER));
 
     // Set errors range to [0,32].

--- a/extras/apps/searchjoin/search.cpp
+++ b/extras/apps/searchjoin/search.cpp
@@ -139,8 +139,8 @@ void setupArgumentParser(ArgumentParser & parser)
 
     addUsageLine(parser, "[\\fIOPTIONS\\fP] <\\fIDATABASE FILE\\fP> <\\fIQUERY FILE\\fP>");
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE));
 
     addSection(parser, "Options");
 

--- a/extras/apps/seqan_flexbar/seqan_flexlib.cpp
+++ b/extras/apps/seqan_flexbar/seqan_flexlib.cpp
@@ -215,13 +215,13 @@ void ArgumentParserBuilder::addDemultiplexingOptions(seqan::ArgumentParser & par
     
     seqan::ArgParseOption barcodeFileOpt = seqan::ArgParseOption(
         "b", "barcodes", "FastA file containing the used barcodes and their IDs. Necessary for demutiplexing.",
-        seqan::ArgParseArgument::INPUTFILE, "BARCODE_FILE");
+        seqan::ArgParseArgument::INPUT_FILE, "BARCODE_FILE");
     setValidValues(barcodeFileOpt, SeqFileIn::getFileFormatExtensions());
     addOption(parser, barcodeFileOpt);
 
     seqan::ArgParseOption multiplexFileOpt = seqan::ArgParseOption(
         "x", "multiplex", "FastA/FastQ file containing the barcode for each read.",
-        seqan::ArgParseArgument::INPUTFILE, "MULTIPLEX_FILE");
+        seqan::ArgParseArgument::INPUT_FILE, "MULTIPLEX_FILE");
     setValidValues(multiplexFileOpt, SeqFileIn::getFileFormatExtensions());
     addOption(parser, multiplexFileOpt);
     
@@ -247,7 +247,7 @@ void ArgumentParserBuilder::addAdapterTrimmingOptions(seqan::ArgumentParser & pa
     seqan::ArgParseOption adapterFileOpt = seqan::ArgParseOption(
         "a", "adapters", "FastA file containing the two adapter sequences. "
         "The adapters according to the layout: 5'-adapter1-read-adapter2-3'.",
-        seqan::ArgParseArgument::INPUTFILE, "ADAPTER_FILE");
+        seqan::ArgParseArgument::INPUT_FILE, "ADAPTER_FILE");
     setValidValues(adapterFileOpt, SeqFileIn::getFileFormatExtensions());
     addOption(parser, adapterFileOpt);
 
@@ -361,7 +361,7 @@ void FilteringParserBuilder::addHeader(seqan::ArgumentParser & parser)
 #endif
     seqan::setVersion(parser, version);
 
-    seqan::ArgParseArgument fileArg(seqan::ArgParseArgument::INPUTFILE, "READS", true);
+    seqan::ArgParseArgument fileArg(seqan::ArgParseArgument::INPUT_FILE, "READS", true);
     setValidValues(fileArg, SeqFileIn::getFileFormatExtensions());
     addArgument(parser, fileArg);
     setHelpText(parser, 0, "Either one (single-end) or two (paired-end) read files.");
@@ -413,7 +413,7 @@ void AdapterRemovalParserBuilder::addHeader(seqan::ArgumentParser & parser)
 #endif
     seqan::setVersion(parser, version);
 
-    seqan::ArgParseArgument fileArg(seqan::ArgParseArgument::INPUTFILE, "READS", true);
+    seqan::ArgParseArgument fileArg(seqan::ArgParseArgument::INPUT_FILE, "READS", true);
     setValidValues(fileArg, SeqFileIn::getFileFormatExtensions());
     addArgument(parser, fileArg);
     setHelpText(parser, 0, "Either one (single-end) or two (paired-end) read files.");
@@ -466,7 +466,7 @@ void DemultiplexingParserBuilder::addHeader(seqan::ArgumentParser & parser)
 #endif
     seqan::setVersion(parser, version);
 
-    seqan::ArgParseArgument fileArg(seqan::ArgParseArgument::INPUTFILE, "READS", true);
+    seqan::ArgParseArgument fileArg(seqan::ArgParseArgument::INPUT_FILE, "READS", true);
     setValidValues(fileArg, SeqFileIn::getFileFormatExtensions());
     addArgument(parser, fileArg);
     setHelpText(parser, 0, "Either one (single-end) or two (paired-end) read files.");
@@ -519,7 +519,7 @@ void QualityControlParserBuilder::addHeader(seqan::ArgumentParser & parser)
 #endif
     seqan::setVersion(parser, version);
 
-    seqan::ArgParseArgument fileArg(seqan::ArgParseArgument::INPUTFILE, "READS", true);
+    seqan::ArgParseArgument fileArg(seqan::ArgParseArgument::INPUT_FILE, "READS", true);
     setValidValues(fileArg, SeqFileIn::getFileFormatExtensions());
     addArgument(parser, fileArg);
     setHelpText(parser, 0, "Either one (single-end) or two (paired-end) read files.");
@@ -578,7 +578,7 @@ void AllStepsParserBuilder::addHeader(seqan::ArgumentParser & parser)
 #endif
     seqan::setVersion(parser, version);
 
-    seqan::ArgParseArgument fileArg(seqan::ArgParseArgument::INPUTFILE, "READS", true);
+    seqan::ArgParseArgument fileArg(seqan::ArgParseArgument::INPUT_FILE, "READS", true);
     setValidValues(fileArg, SeqFileIn::getFileFormatExtensions());
     addArgument(parser, fileArg);
     setHelpText(parser, 0, "Either one (single-end) or two (paired-end) read files.");

--- a/extras/apps/sgip/sgip.cpp
+++ b/extras/apps/sgip/sgip.cpp
@@ -170,7 +170,7 @@ void _setupParser(TParser & parser)
     addDescription(parser, " SGIP - Solution of Graph Isomorphism Problem");
     addUsageLine(parser, "-o <orginal graph> [Option]");    
     addSection(parser, "Mandatory Options");
-    addOption(parser, ArgParseOption("o", "orginal", "File containing orginal graph", ArgParseArgument::INPUTFILE,"IN"));
+    addOption(parser, ArgParseOption("o", "orginal", "File containing orginal graph", ArgParseArgument::INPUT_FILE,"IN"));
     setRequired(parser, "o");
     addSection(parser, "Main Options");
     addOption(parser, ArgParseOption("a", "algorithm", "Algorithm used for searching metric dimension", ArgParseArgument::STRING));
@@ -178,7 +178,7 @@ void _setupParser(TParser & parser)
     addOption(parser, ArgParseOption("s", "searching", "Searching algorithm used for detecting resolving set,heuristic 0 bruteforce 1.", ArgParseArgument::INTEGER));
     setDefaultValue(parser, "searching", "0");
     addOption(parser, ArgParseOption("i", "isomorphism", "To check whether two given graphs are isomorphic"));
-    addOption(parser, ArgParseOption("c", "comparitive", "File containing comparitive graph", ArgParseArgument::INPUTFILE,"IN"));
+    addOption(parser, ArgParseOption("c", "comparitive", "File containing comparitive graph", ArgParseArgument::INPUT_FILE,"IN"));
     addOption(parser, ArgParseOption("od", "odimension", "Specified initial dimension of orginal graph by user", ArgParseArgument::INTEGER));
     setDefaultValue(parser, "odimension", "3");
     addOption(parser, ArgParseOption("cd", "cdimension", "Specified initial dimension of comparitive graph by user", ArgParseArgument::INTEGER));

--- a/extras/apps/variant_comp/variant_comp.cpp
+++ b/extras/apps/variant_comp/variant_comp.cpp
@@ -721,15 +721,15 @@ int main(int argc, const char *argv[])
     setVersion(parser, "1.0");
     setDate(parser, "Jul 2011" );
 
-    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUTFILE, "GENOME", true));
+    addArgument(parser, ArgParseArgument(ArgParseArgument::INPUT_FILE, "GENOME", true));
 
     //////////////////////////////////////////////////////////////////////////////
     // Define options
 
     addSection(parser, "Main Options:");
 
-    addOption(parser, ArgParseOption("ip", "input-predicted", "Input GFF file that contains predicted variants", ArgParseOption::INPUTFILE));
-    addOption(parser, ArgParseOption("ir", "input-reference", "Input GFF file that contains reference variants", ArgParseOption::INPUTFILE));
+    addOption(parser, ArgParseOption("ip", "input-predicted", "Input GFF file that contains predicted variants", ArgParseOption::INPUT_FILE));
+    addOption(parser, ArgParseOption("ir", "input-reference", "Input GFF file that contains reference variants", ArgParseOption::INPUT_FILE));
 
 	addOption(parser, ArgParseOption("pt",  "position-tolerance",   "Position tolerance in bp (for indel comparison)", ArgParseOption::DOUBLE));
     setMinValue(parser, "position-tolerance", "0");   
@@ -745,7 +745,7 @@ int main(int argc, const char *argv[])
 
     addSection(parser, "Output Options:");
 
-    addOption(parser, ArgParseOption("r", "ranges", "File containing ranges of indel sizes to inspect separately (specifying [rangeBegin,rangeEnd) intervals, see example file ranges.txt)", ArgParseOption::INPUTFILE));
+    addOption(parser, ArgParseOption("r", "ranges", "File containing ranges of indel sizes to inspect separately (specifying [rangeBegin,rangeEnd) intervals, see example file ranges.txt)", ArgParseOption::INPUT_FILE));
     addOption(parser, ArgParseOption("o", "output", "Indel output filename", ArgParseOption::OUTPUTFILE));
     addOption(parser, ArgParseOption("on", "outputFN", "Output filename for false negative reference indels", ArgParseOption::OUTPUTFILE));
     addOption(parser, ArgParseOption("os", "outputSnp", "SNP output filename", ArgParseOption::OUTPUTFILE));

--- a/manual/attic/HowTo/GenerateSeqAnKnimeNodes/knime_node.rst
+++ b/manual/attic/HowTo/GenerateSeqAnKnimeNodes/knime_node.rst
@@ -90,7 +90,7 @@
         addDescription(parser, "This is a very simple KNIME node providing an input and output port. The code should be modified such that the node does something useful");
 
         // We require one argument.
-        addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUTFILE, "IN"));
+        addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUT_FILE, "IN"));
         setValidValues(parser, 0, "fastq fq");
 
         addOption(parser, seqan::ArgParseOption("o", "outputFile", "Name of the multi-FASTA output.", seqan::ArgParseOption::OUTPUTFILE, "OUT"));
@@ -178,7 +178,7 @@
             std::cout << "<u>OPTIONS</u><u>_</u><u>_</u><u>_</u><u>_</u><u>_</u><u>_</u><u>_</u><u>_</u><u>_</u><u>_</u><u>_</u><u>_</u><u>_</u>_\n"
                       << '\n'
                       << "VERBOSITY\t" << options.verbosity << '\n'
-                      << "INPUTFILE\t" << options.inputFile << "\n\n"
+                      << "INPUT_FILE\t" << options.inputFile << "\n\n"
                       << "OUTPUTFILE\t" << options.outputFile << "\n\n";
         }
 

--- a/manual/source/HowTo/UseSeqAnNodesInKnime.rst
+++ b/manual/source/HowTo/UseSeqAnNodesInKnime.rst
@@ -56,7 +56,7 @@ Adapt your applications to use the argument parser
 Follow the :ref:`tutorial-parsing-command-line-arguments` tutorial and adapt your application to use only the :dox:`ArgumentParser` to parse command line arguments.
 Especially, take care to:
 
-#. Declare your input and output file names as such via ``ArgParseArgument::INPUTFILE`` and ``ArgParseArgument::OUTPUTFILE``.
+#. Declare your input and output file names as such via ``ArgParseArgument::INPUT_FILE`` and ``ArgParseArgument::OUTPUTFILE``.
 #. Detect the file format from the file extension (and not from a dedicated file format option).
    This can be done, for example, with :dox:`guessFormatFromFilename guessFormatFromFilename()` on an :dox:`AutoSeqFormat` object to detect a particular sequence format (e.g. FASTA) in a predefined set of formats.
 #. For input/output files define a list of possible extensions via :dox:`ArgumentParser#setValidValues setValidValues()` (e.g. "fa fasta"). This list of possible extensions can be generated with :dox:`ArgumentParser#getFileFormatExtensions getFileFormatExtensions()` for a :dox:`TagSelector` of predefined file formats (e.g. AutoSeqFormat).

--- a/manual/source/Tutorial/KnimeNode.rst
+++ b/manual/source/Tutorial/KnimeNode.rst
@@ -66,6 +66,6 @@ The reason for this are incorrectly called bases at the end of the reads.
 .. tip::
 
     KNIME needs to know the input and output ports of a node.
-    Therefore we must specify them using ``ArgParseArgument::INPUTFILE`` or ``ArgParseArgument::OUTPUTFILE`` as can be seen in the 'knime_node' app.
+    Therefore we must specify them using ``ArgParseArgument::INPUT_FILE`` or ``ArgParseArgument::OUTPUTFILE`` as can be seen in the 'knime_node' app.
     In addition, KNIME needs to know the valid file endings, which you can specify with :dox:`ArgParseArgument#setValidValues`, which is also shown in the example.
 

--- a/manual/source/Tutorial/ParsingCommandLineArguments.rst
+++ b/manual/source/Tutorial/ParsingCommandLineArguments.rst
@@ -895,7 +895,7 @@ Input/Output File Names
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 We could use ``ArgParseArgument::STRING`` to specify input and output files.
-However, there are two special argument/option types ``ArgParseArgument::INPUTFILE`` and ``ArgParseArgument::OUTPUTFILE`` that are more suitable:
+However, there are two special argument/option types ``ArgParseArgument::INPUT_FILE`` and ``ArgParseArgument::OUTPUTFILE`` that are more suitable:
 
 #. In the near future, we plan to add basic checks for whether input files exist and are readable by the user.
    You will still have to check whether opening was successful when actually doing this but the program will fail earlier if the source file or target location are not accessible.
@@ -909,7 +909,7 @@ Here is an example for defining input and output file arguments:
 
    addOption(parser, seqan::ArgParseOption(
        "I", "input-file", "Path to the input file",
-       seqan::ArgParseArgument::INPUTFILE, "IN"));
+       seqan::ArgParseArgument::INPUT_FILE, "IN"));
    addOption(parser, seqan::ArgParseOption(
        "O", "output-file", "Path to the output file",
        seqan::ArgParseArgument::OUTPUTFILE, "OUT"));
@@ -982,7 +982,7 @@ Assignment 5
 		addOption(parser, seqan::ArgParseOption(
 		    "I", "input-file",
 		    "A text file that will printed with the modifications applied.",
-		    seqan::ArgParseArgument::INPUTFILE));
+		    seqan::ArgParseArgument::INPUT_FILE));
 		setValidValues(parser, "input-file", "txt");
 		setRequired(parser, "input-file");
 


### PR DESCRIPTION
This makes the enum value name more consistent.

Addresses seqan/seqan#434
