### PR TITLE
[FEATURE] IosOpenMode now always uses std::ios::binary.

### DIFF
--- a/core/include/seqan/basic/basic_stream.h
+++ b/core/include/seqan/basic/basic_stream.h
@@ -276,13 +276,13 @@ struct IosOpenMode<Bidirectional, TDummy>
 
 
 template <typename TDummy>
-const int IosOpenMode<Input, TDummy>::VALUE = std::ios::in;
+const int IosOpenMode<Input, TDummy>::VALUE = std::ios::in | std::ios::binary;
 
 template <typename TDummy>
-const int IosOpenMode<Output, TDummy>::VALUE = std::ios::out;
+const int IosOpenMode<Output, TDummy>::VALUE = std::ios::out | std::ios::binary;
 
 template <typename TDummy>
-const int IosOpenMode<Bidirectional, TDummy>::VALUE = std::ios::in | std::ios::out;
+const int IosOpenMode<Bidirectional, TDummy>::VALUE = std::ios::in | std::ios::out | std::ios::binary;
 
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Fixes seqan/seqan#577
